### PR TITLE
Update README.md. Use new links for shields.io

### DIFF
--- a/ReadMe.md
+++ b/ReadMe.md
@@ -1,9 +1,9 @@
 ﻿# ![NanaZip](Assets/NanaZip.png) NanaZip
 
 [![GitHub Actions Build Status](https://github.com/M2Team/NanaZip/actions/workflows/BuildBinaries.yml/badge.svg?branch=master&event=push)](https://github.com/M2Team/NanaZip/actions/workflows/BuildBinaries.yml?query=event%3Apush+branch%3Amaster)
-[![Latest Version](https://img.shields.io/github/release/M2Team/NanaZip.svg)](https://github.com/M2Team/NanaZip/releases/latest)
-[![Latest Release Downloads](https://img.shields.io/github/downloads/M2Team/NanaZip/latest/total.svg)](https://github.com/M2Team/NanaZip/releases/latest)
-[![Total Downloads](https://img.shields.io/github/downloads/M2Team/NanaZip/total.svg)](https://github.com/M2Team/NanaZip/releases)
+[![Latest Version](https://img.shields.io/github/v/release/M2Team/NanaZip?include_prereleases&display_name=release&sort=date&color=%23a4a61d)](https://github.com/M2Team/NanaZip/releases/latest)
+[![Latest Release Downloads](https://img.shields.io/github/downloads-pre/M2Team/NanaZip/latest/total)](https://github.com/M2Team/NanaZip/releases/latest)
+[![Total Downloads](https://img.shields.io/github/downloads/M2Team/NanaZip/total)](https://github.com/M2Team/NanaZip/releases)
 
 [![Windows Store - Release Channel](https://img.shields.io/badge/Windows%20Store-Release%20Channel-blue)](https://www.microsoft.com/store/apps/9N8G7TSCL18R)
 [![Windows Store - Preview Channel](https://img.shields.io/badge/Windows%20Store-Preview%20Channel-blue)](https://www.microsoft.com/store/apps/9NZL0LRP1BNL)


### PR DESCRIPTION
Current shields.io-images show an error saying `no releases or repo not found`, because there are no releases that are not pre-releases.

Updated the links to use new urls provided by shields.io under categories [version](https://shields.io/category/version) and [downloads](https://shields.io/category/downloads).

The version shield will show the release name (`display_name=release`) instead of the tag name, and is using a custom color (`color=#a4a61d`)to indicate pre-release version. This can be removed later.