### PR TITLE
Allow NanaZip to be associated with any file type

### DIFF
--- a/NanaZipPackage/Package.appxmanifest
+++ b/NanaZipPackage/Package.appxmanifest
@@ -13,7 +13,7 @@
   xmlns:uap8="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"
   xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
   xmlns:virtualization="http://schemas.microsoft.com/appx/manifest/virtualization/windows10"
-  IgnorableNamespaces="uap rescap desktop uap2 uap3 com desktop4 desktop5 uap8 virtualization">
+  IgnorableNamespaces="uap rescap desktop uap2 uap3 com desktop4 desktop5 uap8 uap10 virtualization">
 
   <Identity
     Name="40174MouriNaruto.NanaZipPreview"

--- a/NanaZipPackage/Package.appxmanifest
+++ b/NanaZipPackage/Package.appxmanifest
@@ -11,6 +11,7 @@
   xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
   xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
   xmlns:uap8="http://schemas.microsoft.com/appx/manifest/uap/windows10/8"
+  xmlns:uap10="http://schemas.microsoft.com/appx/manifest/uap/windows10/10"
   xmlns:virtualization="http://schemas.microsoft.com/appx/manifest/virtualization/windows10"
   IgnorableNamespaces="uap rescap desktop uap2 uap3 com desktop4 desktop5 uap8 virtualization">
 
@@ -166,6 +167,7 @@
               <uap:FileType>.z</uap:FileType>
               <uap:FileType>.zip</uap:FileType>
               <uap:FileType>.zst</uap:FileType>
+              <uap10:FileType>*</uap10:FileType>
             </uap:SupportedFileTypes>
           </uap3:FileTypeAssociation>    
       </uap:Extension>


### PR DESCRIPTION
Starting from Windows 10 2004 (build 19041), if you add 
`<uap10:FileType>*</uap10:FileType>`
to the .appxmanifest file, the app can be selected in the "Open With" menu and in Properties>"Change..." for any file type.

This would allow users to associate NanaZip with less common archives which are actually ZIP files such as apk, cbz, jar, nupkg (I used to do the same with 7-Zip).

