### PR TITLE
Fix wrong default SFX stub file name.

### DIFF
--- a/SevenZip/CPP/7zip/UI/GUI/UpdateGUI.cpp
+++ b/SevenZip/CPP/7zip/UI/GUI/UpdateGUI.cpp
@@ -28,7 +28,7 @@ using namespace NWindows;
 using namespace NFile;
 using namespace NDir;
 
-static const char * const kDefaultSfxModule = "7z.sfx";
+static const char * const kDefaultSfxModule = "NanaZipWindows.sfx";
 static const char * const kSFXExtension = "exe";
 
 extern void AddMessageToString(UString &dest, const UString &src);


### PR DESCRIPTION
The default SFX file name in UpdateGUI.cpp was not updated.