### PR TITLE
Workaround for NanaZip not appearing in classic context menu.

### DIFF
--- a/NanaZipPackage/Package.appxmanifest
+++ b/NanaZipPackage/Package.appxmanifest
@@ -261,11 +261,13 @@
         </uap:Extension>
         <desktop4:Extension Category="windows.fileExplorerContextMenus">
           <desktop4:FileExplorerContextMenus>
+            <!-- Our verb name starts with "C" to work around a bug preventing our shell menu from appearing in the
+                 classic context menu. -->
             <desktop5:ItemType Type="Directory">
-              <desktop5:Verb Id="NanaZipShellExtension" Clsid="469D94E9-6AF4-4395-B396-99B1308F8CE5" />
+              <desktop5:Verb Id="CNanaZipShellExtension" Clsid="469D94E9-6AF4-4395-B396-99B1308F8CE5" />
             </desktop5:ItemType>
             <desktop5:ItemType Type="*">
-              <desktop5:Verb Id="NanaZipShellExtension" Clsid="469D94E9-6AF4-4395-B396-99B1308F8CE5" />
+              <desktop5:Verb Id="CNanaZipShellExtension" Clsid="469D94E9-6AF4-4395-B396-99B1308F8CE5" />
             </desktop5:ItemType>
           </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>


### PR DESCRIPTION
This is meant to be a fix for #193, #203 and other related issues.

Basically, when registering the shell extension via MSIX, Windows doesn't accept our current verb name "NanaZipShellExtension" for the "*" file type. The "Directory" file type and normal extensions (e.g. ".zip") work as normal. Registering our extension via [ExplorerCommandHandler](https://gist.github.com/dinhngtu/2be7222068241f6b0801e448dd8c442c) works normally with the same verb.

This patch changes the verb name of our shell extension to work around this issue.

I've tested this patch on the English version of Windows 10 21H2 and Windows 11. There might be some language-related behavior here so testing on other Windows languages would be appreciated.