### PR TITLE
Check 7z compression parameter validity upon start of compression.

### DIFF
--- a/SevenZip/CPP/7zip/UI/Common/CompressCall.cpp
+++ b/SevenZip/CPP/7zip/UI/Common/CompressCall.cpp
@@ -243,14 +243,15 @@ HRESULT CompressFiles(
         params += fo.Method;
       }
 
-      if (fo.Level)
+      /* Level = 0 is meaningful */
+      if (fo.Level != static_cast<UInt32>(-1))
       {
         params += " -mx=";
         ConvertUInt32ToString(fo.Level, temp);
         params += temp;
       }
 
-      if (fo.Dictionary)
+      if (fo.Dictionary && fo.Dictionary != static_cast<UInt32>(-1))
       {
         params += " -md=";
         ConvertUInt32ToString(fo.Dictionary, temp);
@@ -258,7 +259,7 @@ HRESULT CompressFiles(
         params += "b";
       }
 
-      if (fo.BlockLogSize)
+      if (fo.BlockLogSize && fo.BlockLogSize != static_cast<UInt32>(-1))
       {
         params += " -ms=";
         ConvertUInt64ToString(1ULL << fo.BlockLogSize, temp);
@@ -266,7 +267,7 @@ HRESULT CompressFiles(
         params += "b";
       }
 
-      if (fo.NumThreads)
+      if (fo.NumThreads && fo.NumThreads != static_cast<UInt32>(-1))
       {
         params += " -mmt=";
         ConvertUInt32ToString(fo.NumThreads, temp);


### PR DESCRIPTION
Fixes #87. The code to automatically reload compression parameters from Registry didn't check for their validity, leading to invalid parameters being passed to the 7zip worker and therefore causing an out-of-memory error:

` a -i#7zMap[...] -t7z -mx=5 -md=4294967295b -ms=9223372036854775808b -mmt=4294967295 -sae -- [...]`

This patch validates the presence of each parameter before appending it to the parameter string.