### PR TITLE
MSI setup

### DIFF
--- a/NanaZip.sln
+++ b/NanaZip.sln
@@ -128,6 +128,8 @@ Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "NanaZipSetup", "NanaZipSetu
 		{9A119A76-97CB-4490-B8C2-651576CB9302} = {9A119A76-97CB-4490-B8C2-651576CB9302}
 	EndProjectSection
 EndProject
+Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "NanaZipBundle", "NanaZipBundle\NanaZipBundle.wixproj", "{5D871FD0-EBC2-43F6-8BD8-BB7722624500}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -408,6 +410,18 @@ Global
 		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Release|x64.Build.0 = Release|x64
 		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Release|x86.ActiveCfg = Release|x86
 		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Release|x86.Build.0 = Release|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Debug|ARM64.ActiveCfg = Debug|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Debug|ARM64.Build.0 = Debug|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Debug|x64.ActiveCfg = Debug|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Debug|x64.Build.0 = Debug|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Debug|x86.ActiveCfg = Debug|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Debug|x86.Build.0 = Debug|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Release|ARM64.ActiveCfg = Release|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Release|ARM64.Build.0 = Release|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Release|x64.ActiveCfg = Release|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Release|x64.Build.0 = Release|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Release|x86.ActiveCfg = Release|x86
+		{5D871FD0-EBC2-43F6-8BD8-BB7722624500}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NanaZip.sln
+++ b/NanaZip.sln
@@ -123,6 +123,11 @@ Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Mile.Library.Windows", "Mil
 EndProject
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "NanaZip.Shared.Mitigations", "NanaZip.Shared\NanaZip.Shared.Mitigations.vcxproj", "{3B6BA400-CFE5-44E1-A8E3-2DF0CCC5492B}"
 EndProject
+Project("{930C7802-8A8C-48F9-8165-68863BCCD9DD}") = "NanaZipSetup", "NanaZipSetup\NanaZipSetup.wixproj", "{CB53F1CA-3FD2-4394-A635-15161C26668A}"
+	ProjectSection(ProjectDependencies) = postProject
+		{9A119A76-97CB-4490-B8C2-651576CB9302} = {9A119A76-97CB-4490-B8C2-651576CB9302}
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|ARM64 = Debug|ARM64
@@ -391,6 +396,18 @@ Global
 		{3B6BA400-CFE5-44E1-A8E3-2DF0CCC5492B}.Release|x64.Build.0 = Release|x64
 		{3B6BA400-CFE5-44E1-A8E3-2DF0CCC5492B}.Release|x86.ActiveCfg = Release|Win32
 		{3B6BA400-CFE5-44E1-A8E3-2DF0CCC5492B}.Release|x86.Build.0 = Release|Win32
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Debug|ARM64.ActiveCfg = Debug|x86
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Debug|ARM64.Build.0 = Debug|x86
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Debug|x64.ActiveCfg = Debug|x64
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Debug|x64.Build.0 = Debug|x64
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Debug|x86.ActiveCfg = Debug|x86
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Debug|x86.Build.0 = Debug|x86
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Release|ARM64.ActiveCfg = Release|x86
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Release|ARM64.Build.0 = Release|x86
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Release|x64.ActiveCfg = Release|x64
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Release|x64.Build.0 = Release|x64
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Release|x86.ActiveCfg = Release|x86
+		{CB53F1CA-3FD2-4394-A635-15161C26668A}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/NanaZipBundle/Bundle.wxs
+++ b/NanaZipBundle/Bundle.wxs
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi" xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+  <Bundle
+    Name="NanaZip"
+    Version="2.0.313.0"
+    Manufacturer="Kenji Mouri"
+    UpgradeCode="6c83627d-24a4-4cf4-81fd-3caac89b69d1">
+    <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.HyperlinkLicense">
+      <bal:WixStandardBootstrapperApplication
+        LicenseUrl="https://github.com/M2Team/NanaZip/blob/main/License.md"
+        ShowVersion="yes"
+        SuppressOptionsUI="yes"
+        LogoFile="$(var.SolutionDir)\Assets\NanaZip.png" />
+    </BootstrapperApplicationRef>
+
+    <Chain>
+      <MsiPackage Id="NanaZip_x86" InstallCondition="NOT VersionNT64" SourceFile="$(var.SolutionDir)\Output\Binaries\Setup\$(var.Configuration)\x86\NanaZipSetup.msi" />
+      <MsiPackage Id="NanaZip_x64" InstallCondition="VersionNT64" SourceFile="$(var.SolutionDir)\Output\Binaries\Setup\$(var.Configuration)\x64\NanaZipSetup.msi" />
+    </Chain>
+  </Bundle>
+</Wix>

--- a/NanaZipBundle/NanaZipBundle.wixproj
+++ b/NanaZipBundle/NanaZipBundle.wixproj
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>3.10</ProductVersion>
+    <ProjectGuid>5d871fd0-ebc2-43f6-8bd8-bb7722624500</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputName>NanaZipSetup</OutputName>
+    <OutputType>Bundle</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <OutputPath>$(SolutionDir)\Output\Binaries\Setup\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <OutputPath>$(SolutionDir)\Output\Binaries\Setup\$(Configuration)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Bundle.wxs" />
+  </ItemGroup>
+  <ItemGroup>
+    <WixExtension Include="WixBalExtension">
+      <HintPath>$(WixExtDir)\WixBalExtension.dll</HintPath>
+      <Name>WixBalExtension</Name>
+    </WixExtension>
+  </ItemGroup>
+  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
+    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
+  </Target>
+  <!--
+	To modify your build process, add your task inside one of the targets below and uncomment it.
+	Other similar extension points exist, see Wix.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/NanaZipSetup/NanaZipSetup.wixproj
+++ b/NanaZipSetup/NanaZipSetup.wixproj
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" DefaultTargets="Build" InitialTargets="EnsureWixToolsetInstalled" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">x86</Platform>
+    <ProductVersion>3.10</ProductVersion>
+    <ProjectGuid>cb53f1ca-3fd2-4394-a635-15161c26668a</ProjectGuid>
+    <SchemaVersion>2.0</SchemaVersion>
+    <OutputName>NanaZipSetup</OutputName>
+    <OutputType>Package</OutputType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x86' ">
+    <OutputPath>$(SolutionDir)\Output\Binaries\Setup\$(Configuration)\$(Platform)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+    <DefineConstants>Debug</DefineConstants>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x86' ">
+    <OutputPath>$(SolutionDir)\Output\Binaries\Setup\$(Configuration)\$(Platform)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|x64' ">
+    <DefineConstants>Debug</DefineConstants>
+    <OutputPath>$(SolutionDir)\Output\Binaries\Setup\$(Configuration)\$(Platform)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|x64' ">
+    <OutputPath>$(SolutionDir)\Output\Binaries\Setup\$(Configuration)\$(Platform)\</OutputPath>
+    <IntermediateOutputPath>obj\$(Platform)\$(Configuration)\</IntermediateOutputPath>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Product.wxs" />
+  </ItemGroup>
+  <Import Project="$(WixTargetsPath)" Condition=" '$(WixTargetsPath)' != '' " />
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets" Condition=" '$(WixTargetsPath)' == '' AND Exists('$(MSBuildExtensionsPath32)\Microsoft\WiX\v3.x\Wix.targets') " />
+  <Target Name="EnsureWixToolsetInstalled" Condition=" '$(WixTargetsImported)' != 'true' ">
+    <Error Text="The WiX Toolset v3.11 (or newer) build tools must be installed to build this project. To download the WiX Toolset, see http://wixtoolset.org/releases/" />
+  </Target>
+  <!--
+	To modify your build process, add your task inside one of the targets below and uncomment it.
+	Other similar extension points exist, see Wix.targets.
+	<Target Name="BeforeBuild">
+	</Target>
+	<Target Name="AfterBuild">
+	</Target>
+	-->
+</Project>

--- a/NanaZipSetup/Product.wxs
+++ b/NanaZipSetup/Product.wxs
@@ -1,0 +1,117 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi">
+  <?if $(var.Platform) = x86 ?>
+  <?define upgradeCode = "C23EAF1E-2EC1-491A-AA65-57149E095AFD" ?>
+  <?define isWin64 = "no" ?>
+  <?define installDir = "ProgramFilesFolder" ?>
+
+  <?elseif $(var.Platform) = x64 ?>
+  <?define upgradeCode = "92A1E85A-6147-4474-83A0-9DD09B9B8692" ?>
+  <?define isWin64 = "yes" ?>
+  <?define installDir = "ProgramFiles64Folder" ?>
+
+  <?else ?>
+  <?error Unsupported platform ?>
+  <?endif ?>
+
+  <?define sourcePath = "$(var.SolutionDir)\Output\Binaries\$(var.Configuration)\NanaZipPackage\$(var.Platform)" ?>
+
+  <Product
+    Id="*"
+    Name="NanaZip"
+    Language="1033"
+    Version="2.0.313.0"
+    Manufacturer="Kenji Mouri"
+    UpgradeCode="$(var.upgradeCode)">
+
+    <Package InstallerVersion="500" Compressed="yes" InstallScope="perMachine" />
+
+    <MajorUpgrade DowngradeErrorMessage="A newer version of [ProductName] is already installed." />
+    <MediaTemplate EmbedCab="yes" />
+
+    <?if $(var.Platform) = x86 ?>
+    <Condition Message="32-bit setup can only run on a 32-bit OS.">Installed OR (NOT VersionNT64)</Condition>
+    <?endif ?>
+
+    <Feature Id="ProductFeature" Title="NanaZip" AllowAdvertise="no" Absent="disallow">
+      <ComponentGroupRef Id="ProductComponents" />
+      <ComponentGroupRef Id="SfxComponents" />
+    </Feature>
+
+    <Feature Id="ShellExtensionFeature" Title="NanaZip Shell Extension" AllowAdvertise="no">
+      <ComponentGroupRef Id="ShellExtensionComponents" />
+    </Feature>
+
+    <!--<UIRef Id="WixUI_FeatureTree" />-->
+
+    <PropertyRef Id="ARPPRODUCTICON" />
+  </Product>
+
+  <Fragment>
+    <Directory Id="TARGETDIR" Name="SourceDir">
+      <Directory Id="$(var.installDir)">
+        <Directory Id="INSTALLFOLDER" Name="NanaZip" />
+      </Directory>
+    </Directory>
+  </Fragment>
+
+  <Fragment>
+    <DirectoryRef Id="TARGETDIR">
+      <Directory Id="ProgramMenuFolder" />
+    </DirectoryRef>
+  </Fragment>
+
+  <Fragment>
+    <Icon Id="NanaZip.ico" SourceFile="$(var.SolutionDir)\Assets\NanaZip.ico" />
+    <Property Id="ARPPRODUCTICON" Value="NanaZip.ico" />
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="ProductComponents" Directory="INSTALLFOLDER" Source="$(var.sourcePath)">
+      <Component Win64="$(var.isWin64)">
+        <File Name="NanaZip.exe" />
+        <Shortcut Id="NanaZip" Directory="ProgramMenuFolder" Name="NanaZip" WorkingDirectory="INSTALLFOLDER" Advertise="yes" Icon="NanaZip.ico" />
+      </Component>
+      <Component Win64="$(var.isWin64)">
+        <File Name="NanaZipC.exe" />
+      </Component>
+      <Component Win64="$(var.isWin64)">
+        <File Name="NanaZipCore.dll" />
+      </Component>
+      <Component Win64="$(var.isWin64)">
+        <File Name="NanaZipG.exe" />
+      </Component>
+      <Component Win64="$(var.isWin64)">
+        <File Name="resources.pri" DefaultLanguage="!(bind.fileLanguage.NanaZip.exe)" DefaultVersion="!(bind.fileVersion.NanaZip.exe)" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="SfxComponents" Directory="INSTALLFOLDER" Source="$(var.sourcePath)">
+      <!-- We want our SFX files to stay along with EXE files so we have to specify a matching Win64 attribute -->
+      <Component Win64="$(var.isWin64)">
+        <File Name="NanaZipConsole.sfx" />
+      </Component>
+      <Component Win64="$(var.isWin64)">
+        <File Name="NanaZipWindows.sfx" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+
+  <Fragment>
+    <ComponentGroup Id="ShellExtensionComponents" Directory="INSTALLFOLDER" Source="$(var.sourcePath)">
+      <Component Win64="$(var.isWin64)">
+        <File Name="NanaZipShellExtension.dll">
+          <Class Id="469D94E9-6AF4-4395-B396-99B1308F8CE5" Context="InprocServer32" ThreadingModel="apartment" />
+        </File>
+      </Component>
+      <Component Win64="$(var.isWin64)">
+        <RegistryValue Root="HKCR" Key="*\Shell\NanaZipShellExtension" Name="ExplorerCommandHandler" Type="string" Value="{469D94E9-6AF4-4395-B396-99B1308F8CE5}" />
+      </Component>
+      <Component Win64="$(var.isWin64)">
+        <RegistryValue Root="HKCR" Key="Directory\Shell\NanaZipShellExtension" Name="ExplorerCommandHandler" Type="string" Value="{469D94E9-6AF4-4395-B396-99B1308F8CE5}" />
+      </Component>
+    </ComponentGroup>
+  </Fragment>
+</Wix>

--- a/NanaZipShellExtension/NanaZipShellExtension.vcxproj
+++ b/NanaZipShellExtension/NanaZipShellExtension.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="..\Mile.Project.Windows\Mile.Project.Platform.x86.props" />
   <Import Project="..\Mile.Project.Windows\Mile.Project.Platform.x64.props" />
@@ -17,7 +17,7 @@
   <ItemDefinitionGroup>
     <ClCompile>
       <AdditionalOptions>%(AdditionalOptions) /Wv:18</AdditionalOptions>
-      <PreprocessorDefinitions>LANG;WIN_LONG_PATH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PreprocessorDefinitions>LANG_NO_WINRT;LANG;WIN_LONG_PATH;%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
       <LargeAddressAware>true</LargeAddressAware>

--- a/SevenZip/CPP/Common/Lang.cpp
+++ b/SevenZip/CPP/Common/Lang.cpp
@@ -8,6 +8,10 @@
 
 #include "../Windows/FileIO.h"
 
+#ifdef _SFX
+#define LANG_NO_WINRT
+#endif
+
 void CLang::Clear() throw()
 {
 
@@ -26,7 +30,7 @@ bool CLang::Open(CFSTR fileName, const char *id)
     return true;
 }
 
-#ifdef _SFX
+#ifdef LANG_NO_WINRT
 #include "../Windows/ResourceString.h"
 #else
 #include <winrt/windows.foundation.h>
@@ -36,7 +40,7 @@ bool CLang::Open(CFSTR fileName, const char *id)
 
 #include <map>
 
-#ifdef _SFX
+#ifdef LANG_NO_WINRT
 std::map<UInt32, UString> g_LanguageMap;
 #else
 std::map<UInt32, winrt::hstring> g_LanguageMap;
@@ -47,7 +51,7 @@ const wchar_t *CLang::Get(UInt32 id) const throw()
     auto Iterator = g_LanguageMap.find(id);
     if (Iterator == g_LanguageMap.end())
     {
-#ifdef _SFX
+#ifdef LANG_NO_WINRT
         UString Content = NWindows::MyLoadString(id);
         if (Content.IsEmpty())
         {
@@ -78,7 +82,7 @@ const wchar_t *CLang::Get(UInt32 id) const throw()
 #endif    
     }
 
-#ifdef _SFX
+#ifdef LANG_NO_WINRT
     return Iterator->second;
 #else
     return Iterator->second.data();


### PR DESCRIPTION
This (draft) PR adds a MSI-based setup for NanaZip. A setup bundle is included to choose the correct architecture/version at install time.

A change was needed to disable `.pri` resources in the shell extension so that it would work outside of a MSIX package.

The current setup is at an early stage so feedback would be appreciated.

List of ideas to be done:

- [ ] Add support for ARM64 setups. (Requires WiX 3.14 which is not yet stable; I can try upgrading if this is absolutely required)
- [ ] Customize setup UI and branding.
- [ ] Add file type associations.
- [ ] Add NanaZip and its aliases to PATH.
- [ ] Find a way to create dual-purpose setup bundles (supporting both per-user and per-machine installations).