### PR TITLE
Opt out of dynamic code mitigation on main FM thread.

### DIFF
--- a/NanaZip.Shared/Mitigations.h
+++ b/NanaZip.Shared/Mitigations.h
@@ -15,5 +15,6 @@
 #include <Windows.h>
 
 EXTERN_C BOOL WINAPI NanaZipEnableMitigations();
+EXTERN_C BOOL WINAPI NanaZipThreadDynamicCodeAllow();
 
 #endif // !NANAZIP_SHARED_MITIGATIONS

--- a/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
+++ b/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
@@ -683,6 +683,12 @@ int WINAPI WinMain(HINSTANCE hInstance, HINSTANCE /* hPrevInstance */,
     ErrorMessage("Cannot enable security mitigations");
   }
 
+#ifdef NDEBUG
+  // opt out of dynamic code policy on UI thread to prevent Explorer extension incompatibility
+  // ignore errors since they shouldn't be fatal
+  ::NanaZipThreadDynamicCodeAllow();
+#endif
+
   try
   {
     try


### PR DESCRIPTION
Fix #231.

ExplorerPatcher uses IAT hooking to intercept multiple shell API calls. This is not compatible with our dynamic code mitigation.

Enable dynamic code optout on the main FM thread to avoid startup crashes for now.