### PR TITLE
Use modern IFileDialog for folder picker dialog 

### DIFF
--- a/NanaZip.Shared/ModernWin32FileBrowser.cpp
+++ b/NanaZip.Shared/ModernWin32FileBrowser.cpp
@@ -1,0 +1,93 @@
+﻿/*
+ * PROJECT:   NanaZip
+ * FILE:      ModernWin32FileBrowser.cpp
+ * PURPOSE:   Implementation for Modern Win32 File Browser
+ *
+ * LICENSE:   The MIT License
+ *
+ * DEVELOPER: reflectronic (john-tur@outlook.com)
+ *            Mouri_Naruto (Mouri_Naruto AT Outlook.com)
+ */
+
+#include <Windows.h>
+#include <ShlObj_core.h>
+#include <wrl.h>
+
+EXTERN_C PIDLIST_ABSOLUTE WINAPI ModernSHBrowseForFolderW(LPBROWSEINFOW uType)
+{
+    using namespace Microsoft::WRL;
+    ComPtr<IFileDialog> fileDialog;
+    if (FAILED(CoCreateInstance(CLSID_FileOpenDialog, nullptr, CLSCTX_INPROC_SERVER, IID_PPV_ARGS(&fileDialog))))
+    {
+        return nullptr;
+    }
+
+    if (!fileDialog)
+    {
+        return nullptr;
+    }
+
+    DWORD flags;
+    if (FAILED(fileDialog->GetOptions(&flags)))
+    {
+        return nullptr;
+    }
+
+    if (FAILED(fileDialog->SetOptions(flags | FOS_PICKFOLDERS | FOS_FORCEFILESYSTEM)))
+    {
+        return nullptr;
+    }
+
+    if (FAILED(fileDialog->SetTitle(uType->lpszTitle)))
+    {
+        return nullptr;
+    }
+
+    // 7-Zip does not use the pidlRoot parameter to configure the default folder.
+    // Instead, it sets it by configuring the message loop for the shell dialog,
+    // passing the path of the default folder through the lParam, and navigating
+    // to that folder inside the message loop.
+    // 
+    // Since we cannot augment the IFileDialog's message loop, we will reach into
+    // the lParam given to us to find the initial path and hope that 7-Zip does
+    // not change this behavior.
+    ComPtr<IShellItem> defaultFolder;
+    if (FAILED(SHCreateItemFromParsingName(reinterpret_cast<PCWSTR>(uType->lParam), nullptr, IID_IShellItem, &defaultFolder)))
+    {
+        return nullptr;
+    }
+
+    if (FAILED(fileDialog->SetDefaultFolder(defaultFolder.Get())))
+    {
+        return nullptr;
+    }
+
+    HRESULT hr = fileDialog->Show(uType->hwndOwner);
+    if (FAILED(hr))
+    {
+        return nullptr;
+    }
+
+    ComPtr<IShellItem> result;
+    if (FAILED(fileDialog->GetResult(&result)))
+    {
+        return nullptr;
+    }
+
+    LPITEMIDLIST pidl;
+    if (FAILED(SHGetIDListFromObject(result.Get(), &pidl)))
+    {
+        return nullptr;
+    }
+
+    return pidl;
+}
+
+#if defined(_M_IX86)
+#pragma warning(suppress:4483)
+extern "C" __declspec(selectany) void const* const __identifier("_imp__SHBrowseForFolderW@4") = reinterpret_cast<void const*>(::ModernSHBrowseForFolderW);
+#pragma comment(linker, "/include:__imp__SHBrowseForFolderW@4")
+#else
+extern "C" __declspec(selectany) void const* const __imp_SHBrowseForFolderW = reinterpret_cast<void const*>(::ModernSHBrowseForFolderW);
+#pragma comment(linker, "/include:__imp_SHBrowseForFolderW")
+#endif

--- a/NanaZip.Shared/NanaZip.Shared.ModernExperienceShims.props
+++ b/NanaZip.Shared/NanaZip.Shared.ModernExperienceShims.props
@@ -8,7 +8,7 @@
       <PreprocessorDefinitions>%(PreprocessorDefinitions)</PreprocessorDefinitions>
     </ClCompile>
     <Link>
-      <AdditionalDependencies>$(MileProjectObjectsPath)$(Configuration)\NanaZip.Shared.ModernExperienceShims\$(Platform)\ModernWin32MessageBox.obj;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>$(MileProjectObjectsPath)$(Configuration)\NanaZip.Shared.ModernExperienceShims\$(Platform)\ModernWin32MessageBox.obj;$(MileProjectObjectsPath)$(Configuration)\NanaZip.Shared.ModernExperienceShims\$(Platform)\ModernWin32FileBrowser.obj;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
 </Project>

--- a/NanaZip.Shared/NanaZip.Shared.ModernExperienceShims.vcxproj
+++ b/NanaZip.Shared/NanaZip.Shared.ModernExperienceShims.vcxproj
@@ -8,6 +8,7 @@
     <RootNamespace>NanaZip.Shared.ModernExperienceShims</RootNamespace>
     <MileProjectType>StaticLibrary</MileProjectType>
     <MileProjectEnableVCLTLSupport>true</MileProjectEnableVCLTLSupport>
+    <MileProjectEnableCppWinRTSupport>true</MileProjectEnableCppWinRTSupport>
   </PropertyGroup>
   <Import Project="..\Mile.Project.Windows\Mile.Project.Cpp.props" />
   <ItemDefinitionGroup>

--- a/NanaZip.Shared/NanaZip.Shared.ModernExperienceShims.vcxproj
+++ b/NanaZip.Shared/NanaZip.Shared.ModernExperienceShims.vcxproj
@@ -19,6 +19,7 @@
     <None Include="NanaZip.Shared.ModernExperienceShims.props" />
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="ModernWin32FileBrowser.cpp" />
     <ClCompile Include="ModernWin32MessageBox.cpp" />
   </ItemGroup>
   <Import Project="..\Mile.Project.Windows\Mile.Project.Cpp.targets" />


### PR DESCRIPTION
Closes #251

Currently, I have implemented a shim for `SHBrowseForFolderW` that shows uses the Vista Common File Dialog. It does not understand every possible option that `SHBrowseForFolderW` takes, but it is good enough for the purposes of 7-Zip. It is not perfect, and there is one thing in particular that I am not too happy about:

7-Zip sets the dialog's default folder by setting in a custom message loop for the dialog, passing itself the path to the default folder as a string through `LPBROWSEINFOW.lParam`, and navigating to that path when the dialog is initialized. This method cannot work with IFileDialog, so this shim relies on the fact that 7-Zip always passes an `LPWSTR` to the message loop. If 7-Zip ever changes the way they use `SHBrowseForFolderW`, this shim will stop working correctly. If you have a better idea for how to implement this, I am all ears.

| Before | After |
|--------|-------|
| <img width="400" src="https://user-images.githubusercontent.com/27514983/206824954-a2c5cfca-de17-4d74-8aa5-a8876757c816.png" alt="Pre-vista style folder browser" />     | <img width="450" src="https://user-images.githubusercontent.com/27514983/208063323-4011ebab-235c-473a-aadd-8e0347d60b21.png" alt="New vista-style folder browser" />     |



