### PR TITLE
Disable child processes in NanaZipC and NanaZipG.

### DIFF
--- a/NanaZip.Shared/Mitigations.cpp
+++ b/NanaZip.Shared/Mitigations.cpp
@@ -100,6 +100,12 @@ namespace
         static bool CachedResult = ::MileIsWindowsVersionAtLeast(10, 0, 0);
         return CachedResult;
     }
+
+    static bool IsWindows10_1709OrLater()
+    {
+        static bool CachedResult = ::MileIsWindowsVersionAtLeast(10, 0, 16299);
+        return CachedResult;
+    }
 }
 
 EXTERN_C BOOL WINAPI NanaZipEnableMitigations()
@@ -168,4 +174,24 @@ EXTERN_C BOOL WINAPI NanaZipThreadDynamicCodeAllow()
         ThreadDynamicCodePolicy,
         &ThreadPolicy,
         sizeof(DWORD));
+}
+
+EXTERN_C BOOL WINAPI NanaZipDisableChildProcesses()
+{
+    if (!::IsWindows10_1709OrLater())
+    {
+        return TRUE;
+    }
+
+    PROCESS_MITIGATION_CHILD_PROCESS_POLICY Policy = { 0 };
+    Policy.NoChildProcessCreation = 1;
+    if (!::SetProcessMitigationPolicyWrapper(
+        ProcessChildProcessPolicy,
+        &Policy,
+        sizeof(PROCESS_MITIGATION_CHILD_PROCESS_POLICY)))
+    {
+        return FALSE;
+    }
+
+    return TRUE;
 }

--- a/NanaZip.Shared/Mitigations.h
+++ b/NanaZip.Shared/Mitigations.h
@@ -16,5 +16,6 @@
 
 EXTERN_C BOOL WINAPI NanaZipEnableMitigations();
 EXTERN_C BOOL WINAPI NanaZipThreadDynamicCodeAllow();
+EXTERN_C BOOL WINAPI NanaZipDisableChildProcesses();
 
 #endif // !NANAZIP_SHARED_MITIGATIONS

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Console/MainAr.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Console/MainAr.cpp
@@ -77,6 +77,14 @@ int MY_CDECL main
       << NError::MyFormatMessage(GetLastError())
       << endl;
   }
+  if (!::NanaZipDisableChildProcesses())
+  {
+    FlushStreams();
+    *g_ErrStream
+      << "Cannot disable child processes: "
+      << NError::MyFormatMessage(GetLastError())
+      << endl;
+  }
 
   NConsoleClose::CCtrlHandlerSetter ctrlHandlerSetter;
   int res = 0;

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/GUI.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/GUI.cpp
@@ -400,6 +400,10 @@ int APIENTRY WinMain(HINSTANCE  hInstance, HINSTANCE /* hPrevInstance */,
   {
     ErrorMessage("Cannot enable security mitigations");
   }
+  if (!::NanaZipDisableChildProcesses())
+  {
+    ErrorMessage("Cannot disable child processes");
+  }
 
   InitCommonControls();
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Console/MainAr.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Console/MainAr.cpp
@@ -77,6 +77,14 @@ int MY_CDECL main
       << NError::MyFormatMessage(GetLastError())
       << endl;
   }
+  if (!::NanaZipDisableChildProcesses())
+  {
+    FlushStreams();
+    *g_ErrStream
+      << "Cannot disable child processes: "
+      << NError::MyFormatMessage(GetLastError())
+      << endl;
+  }
 
   NConsoleClose::CCtrlHandlerSetter ctrlHandlerSetter;
   int res = 0;

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/GUI.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/GUI.cpp
@@ -400,6 +400,10 @@ int APIENTRY WinMain(HINSTANCE  hInstance, HINSTANCE /* hPrevInstance */,
   {
     ErrorMessage("Cannot enable security mitigations");
   }
+  if (!::NanaZipDisableChildProcesses())
+  {
+    ErrorMessage("Cannot disable child processes");
+  }
 
   InitCommonControls();
 


### PR DESCRIPTION
NanaZipC and NanaZipG have no business creating child processes. Enable the corresponding mitigation policy in these programs.