### PR TITLE
Classic: Link with runtimeobject.lib.

### DIFF
--- a/NanaZip.UI.Classic/NanaZip.vcxproj
+++ b/NanaZip.UI.Classic/NanaZip.vcxproj
@@ -31,7 +31,7 @@
     </ClCompile>
     <Link>
       <LargeAddressAware>true</LargeAddressAware>
-      <AdditionalDependencies>comctl32.lib;htmlhelp.lib;comdlg32.lib;Mpr.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;comctl32.lib;htmlhelp.lib;comdlg32.lib;Mpr.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>mpr.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
     </Link>
   </ItemDefinitionGroup>

--- a/NanaZip.UI.Classic/NanaZipShellExtension.vcxproj
+++ b/NanaZip.UI.Classic/NanaZipShellExtension.vcxproj
@@ -31,7 +31,7 @@
     <Link>
       <LargeAddressAware>true</LargeAddressAware>
       <ModuleDefinitionFile>NanaZipShellExtension.def</ModuleDefinitionFile>
-      <AdditionalDependencies>comctl32.lib;htmlhelp.lib;comdlg32.lib;Mpr.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>runtimeobject.lib;comctl32.lib;htmlhelp.lib;comdlg32.lib;Mpr.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
NanaZip Classic and its shell extension still depend on WinRT `runtimeobject.lib`. Link them to this library.