### PR TITLE
Make the 7-Zip Zstandard branch's specific options translatable

### DIFF
--- a/NanaZipPackage/Strings/en/Legacy.resw
+++ b/NanaZipPackage/Strings/en/Legacy.resw
@@ -639,6 +639,21 @@
   <data name="Resource2508" xml:space="preserve">
     <value>Use &amp;large memory pages</value>
   </data>
+  <data name="Resource2509" xml:space="preserve">
+    <value>Want ArcHistory</value>
+  </data>
+  <data name="Resource2510" xml:space="preserve">
+    <value>Want PathHistory</value>
+  </data>
+  <data name="Resource2511" xml:space="preserve">
+    <value>Want CopyHistory</value>
+  </data>
+  <data name="Resource2512" xml:space="preserve">
+    <value>Want FolderHistory</value>
+  </data>
+  <data name="Resource2513" xml:space="preserve">
+    <value>Use Lowercase Hashes</value>
+  </data>  
   <data name="Resource2900" xml:space="preserve">
     <value>About NanaZip</value>
   </data>

--- a/NanaZipPackage/Strings/pl/Legacy.resw
+++ b/NanaZipPackage/Strings/pl/Legacy.resw
@@ -639,6 +639,21 @@
   <data name="Resource2508" xml:space="preserve">
     <value>&amp;Użyj dużych stron pamięci</value>
   </data>
+  <data name="Resource2509" xml:space="preserve">
+    <value>Zachowaj historię dostępu do archiwów</value>
+  </data>
+  <data name="Resource2510" xml:space="preserve">
+    <value>Zachowaj historię ścieżek do wypakowanych archiwów</value>
+  </data>
+  <data name="Resource2511" xml:space="preserve">
+    <value>Zachowaj historię kopiowania</value>
+  </data>
+  <data name="Resource2512" xml:space="preserve">
+    <value>Zachowaj historię folderów</value>
+  </data>
+  <data name="Resource2513" xml:space="preserve">
+    <value>Małoliterowe sumy kontrolne</value>
+  </data> 
   <data name="Resource2900" xml:space="preserve">
     <value>NanaZip - informacje</value>
   </data>

--- a/NanaZipPackage/Strings/pl/Legacy.resw
+++ b/NanaZipPackage/Strings/pl/Legacy.resw
@@ -646,7 +646,7 @@
     <value>Zachowaj historię ścieżek do wypakowanych archiwów</value>
   </data>
   <data name="Resource2511" xml:space="preserve">
-    <value>Zachowaj historię kopiowania</value>
+    <value>Zachowaj historię ścieżek docelowych kopiowania</value>
   </data>
   <data name="Resource2512" xml:space="preserve">
     <value>Zachowaj historię folderów</value>


### PR DESCRIPTION
After some research, I figured out that these resources have their ID, so can be translated! 

Before:
![Zrzut ekranu 2024-05-23 140152](https://github.com/M2Team/NanaZip/assets/6888027/fee65b47-0e65-4995-96df-efdbcdde1ccc)
After:
![Zrzut ekranu 2024-05-23 140112](https://github.com/M2Team/NanaZip/assets/6888027/541fe557-a189-4540-a495-6689e9e4fed3)

~~I didn't use any of these options and I didn't find much information, any context is appreciated. I make this PR as a draft now, to time as we gather more information. After that, we can also change them to something that sounds more clear (eg. Want ArcHistory to Keep a history of accessed archives), but I leave that decision to @MouriNaruto or NanaZip community.~~
Explanation was found [here](https://sourceforge.net/p/sevenzip/discussion/45797/thread/dc2ac53d/?limit=25) thanks to @MouriNaruto and @Dziubek. Below information may help for other translators.
### ArcHistory
I found some information in the book _"Windows Registry Forensics - Advanced Digital Forensic Analysis of the Windows Registry"_ by Harlan Carvey.
> a list of archives accessed

### PathHistory
Source same as above.
> a list of archive extraction paths

### CopyHistory

Stores copy target paths (eg. copy some file from C:/test/test2/ to C:/test3/test4/, it will store path C:/test3/test4/ on registry).

### FolderHistory

> Folder History. Available on _View_ -> _Folder History_ menu or Alt+F12.

--
PS. I also translated these options to Polish.