### PR TITLE
DllBlock: fix compatibility with Transparent Flyout and Sogou Pinyin

### DIFF
--- a/NanaZip.Shared/DllBlock.cpp
+++ b/NanaZip.Shared/DllBlock.cpp
@@ -53,16 +53,16 @@ namespace
         if (ntHdr->Signature != IMAGE_NT_SIGNATURE || ntHdr->OptionalHeader.NumberOfRvaAndSizes < IMAGE_DIRECTORY_ENTRY_EXPORT)
             return false;
         const IMAGE_DATA_DIRECTORY* dirExport = &(ntHdr->OptionalHeader.DataDirectory[IMAGE_DIRECTORY_ENTRY_EXPORT]);
-        if (dirExport->Size < sizeof(IMAGE_EXPORT_DIRECTORY) || !CheckExtents(viewSize, dirExport->VirtualAddress, sizeof(IMAGE_EXPORT_DIRECTORY))) {
+        if (dirExport->Size < sizeof(IMAGE_EXPORT_DIRECTORY) || !dirExport->VirtualAddress || !CheckExtents(viewSize, dirExport->VirtualAddress, sizeof(IMAGE_EXPORT_DIRECTORY))) {
             return false;
         }
         const IMAGE_EXPORT_DIRECTORY* exports = reinterpret_cast<const IMAGE_EXPORT_DIRECTORY*>(base + dirExport->VirtualAddress);
         // we don't know the export directory name size so assume that at least 256 bytes after the name are safe
-        if (!CheckExtents(viewSize, exports->Name, ARRAYSIZE(dllName))) {
+        if (!exports->Name || !CheckExtents(viewSize, exports->Name, ARRAYSIZE(dllName))) {
             return false;
         }
         const char* name = base + exports->Name;
-        if (strcpy_s(dllName, name)) {
+        if (strncpy_s(dllName, name, _TRUNCATE)) {
             return false;
         }
         return true;

--- a/NanaZip.Shared/DllBlock.cpp
+++ b/NanaZip.Shared/DllBlock.cpp
@@ -30,6 +30,10 @@ namespace
         else if (!::_stricmp(dllName, "ExplorerPatcher.IA-32.dll")) {
             return true;
         }
+        else if (!::_stricmp(dllName, "TFMain64.dll")) {
+            // Translucent Flyouts
+            return true;
+        }
         return false;
     }
 


### PR DESCRIPTION
Fixes #377, #408.

Sogou Pinyin's `resources.dll` does not have an export directory, which confuses the DLL blocker. Fix this issue.

Additionally, truncate overly-long or malformed DLL names.

Finally, block Transparent Flyout's `TFMain64.dll` from loading to fix a crash.