### PR TITLE
Use Extract dialog when extracting without selection.

### DIFF
--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/Panel.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/Panel.cpp
@@ -988,7 +988,7 @@ void CPanel::ExtractArchives()
 {
   if (_parentFolders.Size() > 0)
   {
-    _panelCallback->OnCopy(false, false);
+    ExtractFromArchive();
     return;
   }
   CRecordVector<UInt32> indices;
@@ -1004,6 +1004,41 @@ void CPanel::ExtractArchives()
   else
     outFolder += '*';
   outFolder.Add_PathSepar();
+
+  CContextMenuInfo ci;
+  ci.Load();
+
+  ::ExtractArchives(paths, outFolder
+      , true // showDialog
+      , false // elimDup
+      , ci.WriteZone
+      );
+}
+
+void CPanel::ExtractFromArchive()
+{
+  if (_parentFolders.Size() > 1) {
+    _panelCallback->OnCopy(false, false);
+    return;
+  }
+
+  CRecordVector<UInt32> indices;
+  GetOperatedItemIndices(indices);
+  if (indices.Size() > 0) {
+    _panelCallback->OnCopy(false, false);
+    return;
+  }
+
+  UString path = GetFsPath();
+  if (IsPathSepar(path.Back()))
+      path.DeleteBack();
+  if (path != _parentFolders[0].VirtualPath) {
+    _panelCallback->OnCopy(false, false);
+    return;
+  }
+  UStringVector paths;
+  paths.Add(path);
+  UString outFolder = GetSubFolderNameForExtract2(path);
 
   CContextMenuInfo ci;
   ci.Load();

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/Panel.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/Panel.h
@@ -850,6 +850,7 @@ public:
 
   void GetFilePaths(const CRecordVector<UInt32> &indices, UStringVector &paths, bool allowFolders = false);
   void ExtractArchives();
+  void ExtractFromArchive();
   void TestArchives();
 
   HRESULT CopyTo(CCopyToOptions &options,

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.cpp
@@ -988,7 +988,7 @@ void CPanel::ExtractArchives()
 {
   if (_parentFolders.Size() > 0)
   {
-    _panelCallback->OnCopy(false, false);
+    ExtractFromArchive();
     return;
   }
   CRecordVector<UInt32> indices;
@@ -1004,6 +1004,41 @@ void CPanel::ExtractArchives()
   else
     outFolder += '*';
   outFolder.Add_PathSepar();
+
+  CContextMenuInfo ci;
+  ci.Load();
+
+  ::ExtractArchives(paths, outFolder
+      , true // showDialog
+      , false // elimDup
+      , ci.WriteZone
+      );
+}
+
+void CPanel::ExtractFromArchive()
+{
+  if (_parentFolders.Size() > 1) {
+    _panelCallback->OnCopy(false, false);
+    return;
+  }
+
+  CRecordVector<UInt32> indices;
+  GetOperatedItemIndices(indices);
+  if (indices.Size() > 0) {
+    _panelCallback->OnCopy(false, false);
+    return;
+  }
+
+  UString path = GetFsPath();
+  if (IsPathSepar(path.Back()))
+      path.DeleteBack();
+  if (path != _parentFolders[0].VirtualPath) {
+    _panelCallback->OnCopy(false, false);
+    return;
+  }
+  UStringVector paths;
+  paths.Add(path);
+  UString outFolder = GetSubFolderNameForExtract2(path);
 
   CContextMenuInfo ci;
   ci.Load();

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.h
@@ -850,6 +850,7 @@ public:
 
   void GetFilePaths(const CRecordVector<UInt32> &indices, UStringVector &paths, bool allowFolders = false);
   void ExtractArchives();
+  void ExtractFromArchive();
   void TestArchives();
 
   HRESULT CopyTo(CCopyToOptions &options,


### PR DESCRIPTION
Refer to #403.

When extracting without selecting anything, and if we're in the root of an archive, we should use the Extract dialog instead of the Copy To dialog.