### PR TITLE
Implement fast drag drop support.

### DIFF
--- a/BuildAllTargets.proj
+++ b/BuildAllTargets.proj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project 
+<Project
   DefaultTargets="RefreshVersion;Restore;Build;Packaging"
   xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="NanaZip.Project\NanaZip.Project.props" />
@@ -30,10 +30,13 @@
   <Target Name="Restore">
     <ItemGroup>
       <RestoreProjectReference Include="$(MSBuildThisFileDirectory)NanaZip.slnx">
-        <AdditionalProperties>Configuration=Debug;Platform=x64</AdditionalProperties>   
+        <AdditionalProperties>Configuration=Debug;Platform=x64</AdditionalProperties>
       </RestoreProjectReference>
       <RestoreProjectReference Include="$(MSBuildThisFileDirectory)NanaZip.slnx">
-        <AdditionalProperties>Configuration=Release;Platform=x64</AdditionalProperties>   
+        <AdditionalProperties>Configuration=Release;Platform=x64</AdditionalProperties>
+      </RestoreProjectReference>
+      <RestoreProjectReference Include="$(MSBuildThisFileDirectory)NanaZip.ExtensionPackage\NanaZip.Extension.vcxproj">
+        <AdditionalProperties>Configuration=Release</AdditionalProperties>
       </RestoreProjectReference>
       <RestoreProjectReference Include="$(MSBuildThisFileDirectory)NanaZip.ExtensionPackage\NanaZip.ExtensionPackage.Installer.proj">
         <AdditionalProperties>Configuration=Release</AdditionalProperties>
@@ -58,6 +61,18 @@
       BuildInParallel="True"
       StopOnFirstFailure="True"
       Properties="PreferredToolArchitecture=x64;Configuration=Release;Platform=x64" />
+    <MSBuild
+      Projects="$(MSBuildThisFileDirectory)NanaZip.ExtensionPackage\NanaZip.Extension.vcxproj"
+      Targets="Build"
+      BuildInParallel="True"
+      StopOnFirstFailure="True"
+      Properties="Configuration=Release;Platform=ARM64" />
+    <MSBuild
+      Projects="$(MSBuildThisFileDirectory)NanaZip.ExtensionPackage\NanaZip.Extension.vcxproj"
+      Targets="Build"
+      BuildInParallel="True"
+      StopOnFirstFailure="True"
+      Properties="Configuration=Release;Platform=x64" />
     <MSBuild
       Projects="$(MSBuildThisFileDirectory)NanaZip.ExtensionPackage\NanaZip.ExtensionPackage.Installer.proj"
       Targets="Build"
@@ -128,6 +143,8 @@
     <Copy SourceFiles="$(InputBinariesPath)NanaZipPackage\x64\NanaZip.Universal.Windows.pdb" DestinationFolder="$(OutputSymbolsPath)x64" />
     <Copy SourceFiles="$(InputBinariesPath)NanaZipPackage\x64\NanaZip.Modern.FileManager.pdb" DestinationFolder="$(OutputSymbolsPath)x64" />
     <Copy SourceFiles="$(InputBinariesPath)NanaZipPackage\x64\NanaZip.ShellExtension.pdb" DestinationFolder="$(OutputSymbolsPath)x64" />
+    <Copy SourceFiles="$(InputBinariesPath)arm64\NanaZip.Extension.pdb" DestinationFolder="$(OutputSymbolsPath)arm64" />
+    <Copy SourceFiles="$(InputBinariesPath)x64\NanaZip.Extension.pdb" DestinationFolder="$(OutputSymbolsPath)x64" />
 
     <Exec Command="&quot;$(InputBinariesPath)NanaZipPackage\x64\NanaZip.Universal.Console.exe&quot; a -r .\Output\$(OutputFileNamePrefix)_Binaries.zip .\Output\Binaries\Root\Binaries\*.*" WorkingDirectory="$(MSBuildThisFileDirectory)"/>
     <Exec Command="&quot;$(InputBinariesPath)NanaZipPackage\x64\NanaZip.Universal.Console.exe&quot; a -r .\Output\$(OutputFileNamePrefix)_DebugSymbols.zip .\Output\Binaries\Root\Symbols\*.*" WorkingDirectory="$(MSBuildThisFileDirectory)"/>

--- a/NanaZip.ExtensionPackage/CNanaZipCopyHook.cpp
+++ b/NanaZip.ExtensionPackage/CNanaZipCopyHook.cpp
@@ -1,0 +1,84 @@
+﻿/*
+ * PROJECT:   NanaZip
+ * FILE:      CNanaZipCopyHook.cpp
+ * PURPOSE:   Copy hook implementation
+ *
+ * LICENSE:   The MIT License
+ *
+ * DEVELOPER: dinhngtu (contact@tudinh.xyz)
+ */
+
+#define WIN32_LEAN_AND_MEAN
+
+#include <windows.h>
+#include <exception>
+#include <filesystem>
+#include <Unknwn.h>
+#include <olectl.h>
+#include <shellapi.h>
+#include <strsafe.h>
+
+#include "CopyHook.h"
+#include "CNanaZipCopyHook.hpp"
+
+IFACEMETHODIMP_(UINT)
+CNanaZipCopyHook::CopyCallback(
+    _In_opt_ HWND hwnd,
+    UINT wFunc,
+    UINT wFlags,
+    _In_ PCWSTR pszSrcFile,
+    DWORD dwSrcAttribs,
+    _In_opt_ PCWSTR pszDestFile,
+    DWORD dwDestAttribs) {
+
+    UNREFERENCED_PARAMETER(wFlags);
+    UNREFERENCED_PARAMETER(dwSrcAttribs);
+    UNREFERENCED_PARAMETER(dwDestAttribs);
+
+    try {
+        if (wFunc != FO_COPY && wFunc != FO_MOVE)
+            return IDYES;
+
+        std::filesystem::path SourcePath(pszSrcFile);
+        std::filesystem::path DestinationPath(pszDestFile);
+        if (SourcePath.stem() != COPY_HOOK_PREFIX)
+            return IDYES;
+
+        auto HwndString = SourcePath.extension().wstring();
+        if (!HwndString.length())
+            return IDYES;
+
+        auto DestinationHwnd = reinterpret_cast<HWND>(std::stoull(
+            HwndString.substr(1)));
+        auto DestinationDir = DestinationPath.parent_path();
+        COPY_HOOK_DATA CopyHookData = {};
+        if (FAILED(::StringCchCopyW(
+            &CopyHookData.FileName[0],
+            ARRAYSIZE(CopyHookData.FileName),
+            DestinationDir.c_str())))
+            return IDYES;
+
+        COPYDATASTRUCT CopyMessageData;
+        DWORD_PTR MessageResult;
+
+        CopyMessageData.dwData = COPY_HOOK_COMMAND_COPY;
+        CopyMessageData.cbData = sizeof(COPY_HOOK_DATA);
+        CopyMessageData.lpData = &CopyHookData;
+
+        // we can't use PostMessage since the copydata message needs to stay
+        // alive during the send
+        ::SendMessageTimeoutW(
+            DestinationHwnd,
+            WM_COPYDATA,
+            reinterpret_cast<WPARAM>(hwnd),
+            reinterpret_cast<LPARAM>(&CopyMessageData),
+            SMTO_ABORTIFHUNG,
+            100,
+            &MessageResult);
+        // but it doesn't matter if the caller returns or not
+        return IDNO;
+    } catch (std::exception const& ex) {
+        ::OutputDebugStringA(ex.what());
+        return IDYES;
+    }
+}

--- a/NanaZip.ExtensionPackage/CNanaZipCopyHook.hpp
+++ b/NanaZip.ExtensionPackage/CNanaZipCopyHook.hpp
@@ -1,0 +1,28 @@
+﻿/*
+ * PROJECT:   NanaZip
+ * FILE:      CNanaZipCopyHook.cpp
+ * PURPOSE:   Copy hook implementation
+ *
+ * LICENSE:   The MIT License
+ *
+ * DEVELOPER: dinhngtu (contact@tudinh.xyz)
+ */
+
+#pragma once
+
+#define WIN32_LEAN_AND_MEAN
+
+#include <windows.h>
+#include <winrt/windows.foundation.h>
+#include <ShlObj.h>
+
+struct CNanaZipCopyHook : winrt::implements<CNanaZipCopyHook, ICopyHookW> {
+    STDMETHOD_(UINT, CopyCallback)(
+        _In_opt_ HWND hwnd,
+        UINT wFunc,
+        UINT wFlags,
+        _In_ PCWSTR pszSrcFile,
+        DWORD dwSrcAttribs,
+        _In_opt_ PCWSTR pszDestFile,
+        DWORD dwDestAttribs);
+};

--- a/NanaZip.ExtensionPackage/CopyHook.h
+++ b/NanaZip.ExtensionPackage/CopyHook.h
@@ -1,0 +1,13 @@
+﻿#ifndef COPY_HOOK_H
+#define COPY_HOOK_H
+
+#include <Windows.h>
+
+#define COPY_HOOK_PREFIX "{7F4FD2EA-8CC8-43C4-8440-CD76805B4E95}"
+#define COPY_HOOK_COMMAND_COPY 0x7F4FD2EA
+
+typedef struct _COPY_HOOK_DATA {
+    wchar_t FileName[MAX_PATH];
+} COPY_HOOK_DATA, *PCOPY_HOOK_DATA;
+
+#endif

--- a/NanaZip.ExtensionPackage/DllMain.cpp
+++ b/NanaZip.ExtensionPackage/DllMain.cpp
@@ -1,0 +1,204 @@
+﻿/*
+ * PROJECT:   NanaZip
+ * FILE:      NanaZip.ModernExperience.Com.cpp
+ * PURPOSE:   Entry point and self registration code
+ *
+ * LICENSE:   The MIT License
+ *
+ * DEVELOPER: dinhngtu (contact@tudinh.xyz)
+ */
+
+#define WIN32_LEAN_AND_MEAN
+
+#include <string>
+#include <windows.h>
+#include <unknwn.h>
+
+#include "CNanaZipCopyHook.hpp"
+
+static constexpr size_t GUID_STRING_LENGTH =
+    ARRAYSIZE(L"{12345678-90AB-CDEF-1234-567890ABCDEF}");
+
+static const std::wstring CLSID_REGISTRY_PATH =
+    L"Software\\Classes\\CLSID\\";
+static const std::wstring COPY_HOOK_REGISTRY_PATH =
+    L"Software\\Classes\\Directory\\shellex\\CopyHookHandlers\\";
+
+static HINSTANCE g_hInstance = NULL;
+
+BOOL WINAPI DllMain(
+    HMODULE hModule,
+    DWORD ul_reason_for_call,
+    LPVOID lpReserved)
+{
+    UNREFERENCED_PARAMETER(lpReserved);
+
+    switch (ul_reason_for_call)
+    {
+    case DLL_PROCESS_ATTACH:
+        g_hInstance = hModule;
+        break;
+    case DLL_THREAD_ATTACH:
+    case DLL_THREAD_DETACH:
+    case DLL_PROCESS_DETACH:
+        break;
+    }
+    return TRUE;
+}
+
+struct DECLSPEC_UUID("{542CE69A-6EA7-4D77-9B8F-8F56CEA2BF16}")
+    CNanaZipCopyHookFactory : winrt::implements<
+    CNanaZipCopyHookFactory,
+    IClassFactory>
+{
+    IFACEMETHODIMP CreateInstance(
+        IUnknown * pUnkOuter,
+        REFIID riid,
+        void** ppvObject) WIN_NOEXCEPT
+    {
+        if (pUnkOuter)
+        {
+            return CLASS_E_NOAGGREGATION;
+        }
+
+        try
+        {
+            return winrt::make<CNanaZipCopyHook>()
+                ->QueryInterface(riid, ppvObject);
+        }
+        catch (...)
+        {
+            return winrt::to_hresult();
+        }
+    }
+
+    IFACEMETHODIMP LockServer(BOOL fLock) WIN_NOEXCEPT
+    {
+        if (fLock)
+        {
+            ++winrt::get_module_lock();
+        }
+        else
+        {
+            --winrt::get_module_lock();
+        }
+        return S_OK;
+    }
+};
+
+STDAPI DllCanUnloadNow()
+{
+    if (winrt::get_module_lock())
+    {
+        return S_FALSE;
+    }
+    winrt::clear_factory_cache();
+    return S_OK;
+}
+
+STDAPI DllGetClassObject(
+    _In_ REFCLSID rclsid,
+    _In_ REFIID riid,
+    _Outptr_ LPVOID* ppv)
+{
+    try
+    {
+        *ppv = NULL;
+        if (rclsid == __uuidof(CNanaZipCopyHookFactory))
+        {
+            return winrt::make<CNanaZipCopyHookFactory>()
+                ->QueryInterface(riid, ppv);
+        }
+        return E_INVALIDARG;
+    }
+    catch (...)
+    {
+        return winrt::to_hresult();
+    }
+}
+
+STDAPI DllRegisterServer()
+{
+    try
+    {
+        wchar_t clsid[GUID_STRING_LENGTH];
+
+        auto clsidLen = ::StringFromGUID2(
+            __uuidof(CNanaZipCopyHookFactory),
+            clsid,
+            ARRAYSIZE(clsid));
+        if (!clsidLen)
+        {
+            winrt::throw_hresult(E_OUTOFMEMORY);
+        }
+
+        auto serverKeyName = CLSID_REGISTRY_PATH + clsid + L"\\InprocServer32";
+
+        wchar_t dllPath[MAX_PATH];
+        ::SetLastError(ERROR_SUCCESS);
+        auto dllPathLen = ::GetModuleFileNameW(
+            g_hInstance,
+            dllPath,
+            ARRAYSIZE(dllPath));
+        winrt::check_win32(::GetLastError());
+
+        winrt::check_win32(::RegSetKeyValueW(
+            HKEY_CURRENT_USER,
+            serverKeyName.c_str(),
+            NULL,
+            REG_SZ,
+            dllPath,
+            sizeof(wchar_t) * (dllPathLen + 1)));
+        winrt::check_win32(::RegSetKeyValueW(
+            HKEY_CURRENT_USER,
+            serverKeyName.c_str(),
+            L"ThreadingModel",
+            REG_SZ,
+            L"Apartment",
+            sizeof(L"Apartment")));
+
+        auto handlerKeyName = COPY_HOOK_REGISTRY_PATH + clsid;
+        winrt::check_win32(::RegSetKeyValueW(
+            HKEY_CURRENT_USER,
+            handlerKeyName.c_str(),
+            NULL,
+            REG_SZ,
+            clsid,
+            sizeof(wchar_t) * (clsidLen + 1)));
+
+        return S_OK;
+    }
+    catch (...)
+    {
+        return winrt::to_hresult();
+    }
+}
+
+STDAPI DllUnregisterServer()
+{
+    try
+    {
+        wchar_t clsid[GUID_STRING_LENGTH];
+
+        if (!::StringFromGUID2(
+            __uuidof(CNanaZipCopyHookFactory),
+            clsid,
+            ARRAYSIZE(clsid)))
+            winrt::throw_hresult(E_OUTOFMEMORY);
+
+        auto handlerKeyName = COPY_HOOK_REGISTRY_PATH + clsid;
+        ::RegDeleteKeyExW(HKEY_CURRENT_USER, handlerKeyName.c_str(), 0, 0);
+
+        auto serverKeyName = CLSID_REGISTRY_PATH + clsid + L"\\InprocServer32";
+        ::RegDeleteKeyExW(HKEY_CURRENT_USER, serverKeyName.c_str(), 0, 0);
+
+        auto clsidKeyName = CLSID_REGISTRY_PATH + clsid;
+        ::RegDeleteKeyExW(HKEY_CURRENT_USER, clsidKeyName.c_str(), 0, 0);
+
+        return S_OK;
+    }
+    catch (...)
+    {
+        return winrt::to_hresult();
+    }
+}

--- a/NanaZip.ExtensionPackage/NanaZip.Extension.def
+++ b/NanaZip.ExtensionPackage/NanaZip.Extension.def
@@ -1,0 +1,8 @@
+LIBRARY
+
+EXPORTS
+
+DllCanUnloadNow PRIVATE
+DllGetClassObject PRIVATE
+DllRegisterServer PRIVATE
+DllUnregisterServer PRIVATE

--- a/NanaZip.ExtensionPackage/NanaZip.Extension.manifest
+++ b/NanaZip.ExtensionPackage/NanaZip.Extension.manifest
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+	<dependency>
+		<dependentAssembly>
+			<assemblyIdentity
+				type="win32"
+				name="Microsoft.Windows.Common-Controls"
+				version="6.0.0.0"
+				processorArchitecture="*"
+				publicKeyToken="6595b64144ccf1df"
+				language="*"/>
+		</dependentAssembly>
+	</dependency>
+</assembly>

--- a/NanaZip.ExtensionPackage/NanaZip.Extension.vcxproj
+++ b/NanaZip.ExtensionPackage/NanaZip.Extension.vcxproj
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{117927E0-D4CB-43E8-86DD-AB26A4845FF7}</ProjectGuid>
+    <RootNamespace>NanaZip.Extension</RootNamespace>
+    <MileProjectType>DynamicLibrary</MileProjectType>
+    <MileProjectManifestFile>NanaZip.Extension.manifest</MileProjectManifestFile>
+    <MinimalCoreWin>false</MinimalCoreWin>
+    <DefaultLanguage>en</DefaultLanguage>
+    <AppContainerApplication>false</AppContainerApplication>
+    <ApplicationType>Windows Store</ApplicationType>
+    <ApplicationTypeRevision>10.0</ApplicationTypeRevision>
+    <XamlComponentResourceLocation>nested</XamlComponentResourceLocation>
+    <WindowsTargetPlatformMinVersion>10.0.19041.0</WindowsTargetPlatformMinVersion>
+    <MileUniCrtDisableRuntimeDebuggingFeature>true</MileUniCrtDisableRuntimeDebuggingFeature>
+    <MileProjectEnableCppWinRTSupport>true</MileProjectEnableCppWinRTSupport>
+    <MileProjectUseProjectProperties>true</MileProjectUseProjectProperties>
+    <MileProjectCompanyName>M2-Team</MileProjectCompanyName>
+    <MileProjectFileDescription>NanaZip Extension</MileProjectFileDescription>
+    <MileProjectInternalName>NanaZip.Extension</MileProjectInternalName>
+    <MileProjectLegalCopyright>© M2-Team and Contributors. All rights reserved.</MileProjectLegalCopyright>
+    <MileProjectOriginalFilename>NanaZip.Extension.dll</MileProjectOriginalFilename>
+    <MileProjectProductName>NanaZip</MileProjectProductName>
+  </PropertyGroup>
+  <Import Project="..\NanaZip.Project\NanaZip.Project.props" />
+  <Import Sdk="Mile.Project.Configurations" Version="1.0.1917" Project="Mile.Project.Platform.x64.props" />
+  <Import Sdk="Mile.Project.Configurations" Version="1.0.1917" Project="Mile.Project.Platform.ARM64.props" />
+  <Import Sdk="Mile.Project.Configurations" Version="1.0.1917" Project="Mile.Project.Cpp.Default.props" />
+  <Import Sdk="Mile.Project.Configurations" Version="1.0.1917" Project="Mile.Project.Cpp.props" />
+  <ItemDefinitionGroup>
+    <Link>
+      <ModuleDefinitionFile>NanaZip.Extension.def</ModuleDefinitionFile>
+      <LargeAddressAware>true</LargeAddressAware>
+      <MinimumRequiredVersion>10.0</MinimumRequiredVersion>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <RuntimeLibrary Condition="'$(Configuration)' == 'Debug'">MultiThreadedDebug</RuntimeLibrary>
+      <RuntimeLibrary Condition="'$(Configuration)' == 'Release'">MultiThreaded</RuntimeLibrary>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup>
+    <ClCompile>
+      <PreprocessorDefinitions>WINRT_NO_SOURCE_LOCATION;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <AdditionalDependencies>runtimeobject.lib;%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <None Include="NanaZip.Extension.def" />
+  </ItemGroup>
+  <ItemGroup>
+    <Manifest Include="NanaZip.Extension.manifest" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="CNanaZipCopyHook.cpp" />
+    <ClCompile Include="DllMain.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="CopyHook.h" />
+    <ClInclude Include="CNanaZipCopyHook.hpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Mile.Windows.Helpers">
+      <Version>1.0.952</Version>
+    </PackageReference>
+    <PackageReference Include="Mile.Windows.UniCrt">
+      <Version>1.2.410</Version>
+    </PackageReference>
+  </ItemGroup>
+  <Import Sdk="Mile.Project.Configurations" Version="1.0.1917" Project="Mile.Project.Cpp.targets" />
+</Project>

--- a/NanaZip.ExtensionPackage/NanaZip.ExtensionPackage.Installer.iss
+++ b/NanaZip.ExtensionPackage/NanaZip.ExtensionPackage.Installer.iss
@@ -4,8 +4,10 @@
 #define AppURL "https://github.com/M2Team/NanaZip"
 
 #ifndef AppVersion
-#define AppVersion "5.1.0.0"
+#define AppVersion "6.0.0.0"
 #endif
+
+#define ShellextClsid "{{542CE69A-6EA7-4D77-9B8F-8F56CEA2BF16}"
 
 [Setup]
 AppId={{42795434-AB1A-4197-A724-F13E08953DFC}
@@ -28,8 +30,23 @@ OutputBaseFilename=NanaZip.ExtensionPackage_{#AppVersion}
 SolidCompression=yes
 WizardStyle=modern
 
-ArchitecturesAllowed=x64compatible or arm64
-ArchitecturesInstallIn64BitMode=x64compatible or arm64
+ArchitecturesAllowed=x64os or arm64
+ArchitecturesInstallIn64BitMode=x64os or arm64
+
+#ifdef InputPath
+SourceDir="{#InputPath}"
+#endif
+
+[Files]
+Source: "x64\NanaZip.Extension.dll"; DestDir: {app}; Flags: 64bit uninsrestartdelete; Check: IsX64OS
+Source: "ARM64\NanaZip.Extension.dll"; DestDir: {app}; Flags: 64bit uninsrestartdelete; Check: IsArm64
+
+[Registry]
+Root: HKA; Subkey: "Software\Classes\CLSID\{#ShellextClsid}"; Flags: uninsdeletekeyifempty
+Root: HKA; Subkey: "Software\Classes\CLSID\{#ShellextClsid}\InprocServer32"; ValueType: string; ValueName: "ThreadingModel"; ValueData: "Apartment"; Flags: uninsdeletevalue uninsdeletekeyifempty
+Root: HKA; Subkey: "Software\Classes\CLSID\{#ShellextClsid}\InprocServer32"; ValueType: string; ValueData: "{app}\NanaZip.Extension.dll"; Flags: uninsdeletevalue uninsdeletekeyifempty
+
+Root: HKA; Subkey: "Software\Classes\Directory\shellex\CopyHookHandlers\{#ShellextClsid}"; ValueType: string; ValueData: "{#ShellextClsid}"; Flags: uninsdeletevalue uninsdeletekeyifempty
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/NanaZip.ExtensionPackage/NanaZip.ExtensionPackage.Installer.proj
+++ b/NanaZip.ExtensionPackage/NanaZip.ExtensionPackage.Installer.proj
@@ -4,15 +4,16 @@
   <PropertyGroup>
     <TargetFramework>netstandard2.0</TargetFramework>
     <Version>$(MileProjectVersion)</Version>
+    <InstallerInputPath>$(MSBuildThisFileDirectory)..\Output\Binaries\$(Configuration)</InstallerInputPath>
     <InstallerOutputPath>$(MSBuildThisFileDirectory)..\Output</InstallerOutputPath>
   </PropertyGroup>
 
   <!-- NOTE: verify Tools.InnoSetup package binaries with official binaries every upgrade -->
   <ItemGroup>
-    <PackageReference Include="Tools.InnoSetup" Version="6.4.2" />
+    <PackageReference Include="Tools.InnoSetup" Version="6.4.3" />
   </ItemGroup>
 
   <Target Name="BuildInstaller" BeforeTargets="AfterBuild">
-    <Exec Command='"$(InnoSetupCompiler)" "$(MSBuildProjectName).iss" "/DAppVersion=$(Version)" "/O$(InstallerOutputPath)"' />
+    <Exec Command='"$(InnoSetupCompiler)" "$(MSBuildProjectName).iss" "/DAppVersion=$(Version)" "/DInputPath=$(InstallerInputPath)" "/O$(InstallerOutputPath)"' />
   </Target>
 </Project>

--- a/NanaZip.UI.Classic/NanaZip.vcxproj
+++ b/NanaZip.UI.Classic/NanaZip.vcxproj
@@ -240,6 +240,7 @@
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="SevenZip\CPP\7zip\Archive\Common\ItemNameUtils.h" />
+    <ClInclude Include="SevenZip\CPP\7zip\UI\Explorer\CopyHook.h" />
     <ClInclude Include="SevenZip\CPP\7zip\UI\Explorer\MyExplorerCommand.h" />
     <ClInclude Include="SevenZip\CPP\Common\DynLimBuf.h" />
     <ClInclude Include="SevenZip\C\7zTypes.h" />

--- a/NanaZip.UI.Classic/NanaZip.vcxproj.filters
+++ b/NanaZip.UI.Classic/NanaZip.vcxproj.filters
@@ -1075,6 +1075,9 @@
     <ClInclude Include="AboutDialog.h">
       <Filter>AboutDialog</Filter>
     </ClInclude>
+    <ClInclude Include="SevenZip\CPP\7zip\UI\Explorer\CopyHook.h">
+      <Filter>SevenZip\UI\Explorer</Filter>
+    </ClInclude>
   </ItemGroup>
   <ItemGroup>
     <Manifest Include="NanaZip.manifest" />

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Explorer/CopyHook.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Explorer/CopyHook.h
@@ -1,0 +1,13 @@
+﻿#ifndef COPY_HOOK_H
+#define COPY_HOOK_H
+
+#include "../../../Common/MyWindows.h"
+
+#define COPY_HOOK_PREFIX "{7F4FD2EA-8CC8-43C4-8440-CD76805B4E95}"
+#define COPY_HOOK_COMMAND_COPY 0x7F4FD2EA
+
+typedef struct _COPY_HOOK_DATA {
+    wchar_t FileName[MAX_PATH];
+} COPY_HOOK_DATA, *PCOPY_HOOK_DATA;
+
+#endif

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
@@ -25,6 +25,10 @@
 
 #include "../GUI/ExtractRes.h"
 
+// **************** NanaZip Modification Start ****************
+#include "../Explorer/CopyHook.h"
+// **************** NanaZip Modification End ****************
+
 #include "resource.h"
 
 #include "App.h"
@@ -1126,7 +1130,44 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
             SWP_NOZORDER | SWP_NOACTIVATE);
 
         ::UpdateWindow(hWnd);
+        // **************** NanaZip Modification Start ****************
+        break;
+        // **************** NanaZip Modification End ****************
     }
+
+    // **************** NanaZip Modification Start ****************
+    case WM_COPYDATA:
+    {
+        PCOPYDATASTRUCT CopyDataStruct = reinterpret_cast<PCOPYDATASTRUCT>(
+            lParam);
+
+        if (CopyDataStruct->dwData == COPY_HOOK_COMMAND_COPY &&
+            CopyDataStruct->cbData == sizeof(COPY_HOOK_DATA))
+        {
+            CPanel& Panel = g_App.Panels[g_App.LastFocusedPanel];
+            PCOPY_HOOK_DATA Data = static_cast<PCOPY_HOOK_DATA>(
+                CopyDataStruct->lpData);
+            CCopyToOptions Options;
+
+            Options.folder = UString(Data->FileName);
+            Options.showErrorMessages = true;
+
+            CRecordVector<UInt32> Indices;
+            Panel.GetOperatedItemIndices(Indices);
+            if (Indices.Size() > 0)
+            {
+                HRESULT Result = Panel.CopyTo(Options, Indices, nullptr);
+
+                if (Result != S_OK && Result != E_ABORT)
+                {
+                    Panel.MessageBox_Error_HRESULT(Result);
+                }
+            }
+            return TRUE;
+        }
+        break;
+    }
+    // **************** NanaZip Modification End ****************
   }
   #ifndef _UNICODE
   if (g_IsNT)

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/PanelDrag.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/PanelDrag.cpp
@@ -319,6 +319,40 @@ static bool CopyNamesToHGlobal(NMemory::CGlobal &hgDrop, const UStringVector &na
   return true;
 }
 
+// **************** NanaZip Modification Start ****************
+static BOOL FastDragDropAvailable()
+{
+    if (!WantFastDragDrop())
+    {
+        return FALSE;
+    }
+
+    static TOKEN_ELEVATION_TYPE CachedElevation = ([]() -> TOKEN_ELEVATION_TYPE
+    {
+        TOKEN_ELEVATION_TYPE CurrentElevation;
+        DWORD Length = sizeof(CurrentElevation);
+        if (!GetTokenInformation(
+            GetCurrentProcessToken(),
+            TokenElevationType,
+            &CurrentElevation,
+            Length,
+            &Length))
+        {
+            // Fallback to disable
+            return TokenElevationTypeFull;
+        }
+        return CurrentElevation;
+    }());
+
+    if (CachedElevation == TokenElevationTypeFull)
+    {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+// **************** NanaZip Modification End ****************
+
 void CPanel::OnDrag(LPNMLISTVIEW /* nmListView */)
 {
   if (!DoesItSupportOperations())
@@ -339,7 +373,7 @@ void CPanel::OnDrag(LPNMLISTVIEW /* nmListView */)
   CTempDir tempDirectory;
 
   // **************** NanaZip Modification Start ****************
-  bool FastDragDrop = WantFastDragDrop();
+  bool FastDragDrop = FastDragDropAvailable();
   FString FakeDirPath;
   // **************** NanaZip Modification End ****************
 

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.cpp
@@ -30,6 +30,9 @@ static LPCTSTR const kFullRow = TEXT("FullRow");
 static LPCTSTR const kShowGrid = TEXT("ShowGrid");
 static LPCTSTR const kSingleClick = TEXT("SingleClick");
 static LPCTSTR const kAlternativeSelection = TEXT("AlternativeSelection");
+// **************** NanaZip Modification Start ****************
+static LPCTSTR const FastDragDropSetting = TEXT("FastDragDrop");
+// **************** NanaZip Modification End ****************
 // static LPCTSTR const kUnderline = TEXT("Underline");
 
 static LPCTSTR const kShowSystemMenu = TEXT("ShowSystemMenu");
@@ -152,6 +155,9 @@ void CFmSettings::Save() const
   SaveOption(kCopyHistory, CopyHistory);
   SaveOption(kFolderHistory, FolderHistory);
   SaveOption(kLowercaseHashes, LowercaseHashes);
+  // **************** NanaZip Modification Start ****************
+  SaveOption(FastDragDropSetting, this->FastDragDrop);
+  // **************** NanaZip Modification End ****************
   // SaveOption(kUnderline, Underline);
 
   SaveOption(kShowSystemMenu, ShowSystemMenu);
@@ -170,6 +176,9 @@ void CFmSettings::Load()
   CopyHistory = false;
   FolderHistory = false;
   LowercaseHashes = false;
+  // **************** NanaZip Modification Start ****************
+  this->FastDragDrop = false;
+  // **************** NanaZip Modification End ****************
   // Underline = false;
 
   ShowSystemMenu = false;
@@ -188,6 +197,9 @@ void CFmSettings::Load()
     ReadOption(key, kCopyHistory, CopyHistory);
     ReadOption(key, kFolderHistory, FolderHistory);
     ReadOption(key, kLowercaseHashes, LowercaseHashes);
+    // **************** NanaZip Modification Start ****************
+    ReadOption(key, FastDragDropSetting, this->FastDragDrop);
+    // **************** NanaZip Modification End ****************
     // ReadOption(key, kUnderline, Underline);
 
     ReadOption(key, kShowSystemMenu, ShowSystemMenu );
@@ -206,6 +218,9 @@ bool WantPathHistory() { return ReadFMOption(kPathHistory); }
 bool WantCopyHistory() { return ReadFMOption(kCopyHistory); }
 bool WantFolderHistory() { return ReadFMOption(kFolderHistory); }
 bool WantLowercaseHashes() { return ReadFMOption(kLowercaseHashes); }
+// **************** NanaZip Modification Start ****************
+bool WantFastDragDrop() { return ReadFMOption(FastDragDropSetting); }
+// **************** NanaZip Modification End ****************
 
 static CSysString GetFlatViewName(UInt32 panelIndex)
 {

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.h
@@ -30,6 +30,9 @@ struct CFmSettings
   bool CopyHistory;
   bool FolderHistory;
   bool LowercaseHashes;
+  // **************** NanaZip Modification Start ****************
+  bool FastDragDrop;
+  // **************** NanaZip Modification End ****************
   // bool Underline;
 
   bool ShowSystemMenu;
@@ -49,6 +52,9 @@ bool WantPathHistory();
 bool WantCopyHistory();
 bool WantFolderHistory();
 bool WantLowercaseHashes();
+// **************** NanaZip Modification Start ****************
+bool WantFastDragDrop();
+// **************** NanaZip Modification End ****************
 
 void SaveFlatView(UInt32 panelIndex, bool enable);
 bool ReadFlatView(UInt32 panelIndex);

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPage.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPage.cpp
@@ -34,6 +34,9 @@ static const UInt32 kLangIDs[] =
   IDX_SETTINGS_WANT_COPY_HISTORY,
   IDX_SETTINGS_WANT_FOLDER_HISTORY,
   IDX_SETTINGS_LOWERCASE_HASHES,
+  // **************** NanaZip Modification Start ****************
+  IDX_SETTINGS_FAST_DRAG_DROP,
+  // **************** NanaZip Modification End ****************
   // , IDT_COMPRESS_MEMORY
 };
 
@@ -125,6 +128,9 @@ bool CSettingsPage::OnInit()
   CheckButton(IDX_SETTINGS_SHOW_GRID, st.ShowGrid);
   CheckButton(IDX_SETTINGS_SINGLE_CLICK, st.SingleClick);
   CheckButton(IDX_SETTINGS_ALTERNATIVE_SELECTION, st.AlternativeSelection);
+  // **************** NanaZip Modification Start ****************
+  CheckButton(IDX_SETTINGS_FAST_DRAG_DROP, st.FastDragDrop);
+  // **************** NanaZip Modification End ****************
   // CheckButton(IDX_SETTINGS_UNDERLINE, st.Underline);
 
   CheckButton(IDX_SETTINGS_SHOW_SYSTEM_MENU, st.ShowSystemMenu);
@@ -224,6 +230,9 @@ LONG CSettingsPage::OnApply()
     st.CopyHistory = IsButtonCheckedBool(IDX_SETTINGS_WANT_COPY_HISTORY);
     st.FolderHistory = IsButtonCheckedBool(IDX_SETTINGS_WANT_FOLDER_HISTORY);
     st.LowercaseHashes = IsButtonCheckedBool(IDX_SETTINGS_LOWERCASE_HASHES);
+    // **************** NanaZip Modification Start ****************
+    st.FastDragDrop = IsButtonCheckedBool(IDX_SETTINGS_FAST_DRAG_DROP);
+    // **************** NanaZip Modification End ****************
     // st.Underline = IsButtonCheckedBool(IDX_SETTINGS_UNDERLINE);
 
     st.ShowSystemMenu = IsButtonCheckedBool(IDX_SETTINGS_SHOW_SYSTEM_MENU);
@@ -341,6 +350,9 @@ bool CSettingsPage::OnButtonClicked(int buttonID, HWND buttonHWND)
     case IDX_SETTINGS_FULL_ROW:
     case IDX_SETTINGS_SHOW_GRID:
     case IDX_SETTINGS_ALTERNATIVE_SELECTION:
+    // **************** NanaZip Modification Start ****************
+    case IDX_SETTINGS_FAST_DRAG_DROP:
+    // **************** NanaZip Modification End ****************
     case IDX_SETTINGS_WANT_ARC_HISTORY:
     case IDX_SETTINGS_WANT_PATH_HISTORY:
     case IDX_SETTINGS_WANT_COPY_HISTORY:

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPage2.rc
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPage2.rc
@@ -18,6 +18,8 @@ BEGIN
   CONTROL  "Want CopyHistory",   IDX_SETTINGS_WANT_COPY_HISTORY,      MY_CHECKBOX, m, 168, xc, 10
   CONTROL  "Want FolderHistory", IDX_SETTINGS_WANT_FOLDER_HISTORY,    MY_CHECKBOX, m, 182, xc, 10
   CONTROL  "Use Lowercase Hashes", IDX_SETTINGS_LOWERCASE_HASHES,     MY_CHECKBOX, m, 196, xc, 10
+
+  CONTROL  "Use fast drag-and-drop", IDX_SETTINGS_FAST_DRAG_DROP,     MY_CHECKBOX, m, 214, xc, 10
   // **************** NanaZip Modification End ****************
 
   // LTEXT     "Memory usage for Compressing:", IDT_COMPRESS_MEMORY, m, 140, xc, 8

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPageRes.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPageRes.h
@@ -14,6 +14,9 @@
 #define IDX_SETTINGS_WANT_COPY_HISTORY      2511
 #define IDX_SETTINGS_WANT_FOLDER_HISTORY    2512
 #define IDX_SETTINGS_LOWERCASE_HASHES       2513
+// **************** NanaZip Modification Start ****************
+#define IDX_SETTINGS_FAST_DRAG_DROP         2515
+// **************** NanaZip Modification End ****************
 
 
 // #define IDT_SETTINGS_MEM     100

--- a/NanaZip.UI.Modern/NanaZip.Modern.FileManager.vcxproj
+++ b/NanaZip.UI.Modern/NanaZip.Modern.FileManager.vcxproj
@@ -199,6 +199,7 @@
   <ItemGroup>
     <ClInclude Include="NanaZip.UI.h" />
     <ClInclude Include="SevenZip\CPP\7zip\Archive\Common\ItemNameUtils.h" />
+    <ClInclude Include="SevenZip\CPP\7zip\UI\Explorer\CopyHook.h" />
     <ClInclude Include="SevenZip\CPP\7zip\UI\Explorer\MyExplorerCommand.h" />
     <ClInclude Include="SevenZip\CPP\Common\DynLimBuf.h" />
     <ClInclude Include="SevenZip\C\7zTypes.h" />

--- a/NanaZip.UI.Modern/NanaZip.Modern.FileManager.vcxproj.filters
+++ b/NanaZip.UI.Modern/NanaZip.Modern.FileManager.vcxproj.filters
@@ -1022,6 +1022,9 @@
     <ClInclude Include="SevenZip\CPP\Common\DynLimBuf.h">
       <Filter>SevenZip\Common</Filter>
     </ClInclude>
+    <ClInclude Include="SevenZip\CPP\7zip\UI\Explorer\CopyHook.h">
+      <Filter>SevenZip\UI\Explorer</Filter>
+    </ClInclude>
     <ClInclude Include="NanaZip.UI.h" />
   </ItemGroup>
   <ItemGroup>

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Explorer/CopyHook.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Explorer/CopyHook.h
@@ -1,0 +1,13 @@
+﻿#ifndef COPY_HOOK_H
+#define COPY_HOOK_H
+
+#include "../../../Common/MyWindows.h"
+
+#define COPY_HOOK_PREFIX "{7F4FD2EA-8CC8-43C4-8440-CD76805B4E95}"
+#define COPY_HOOK_COMMAND_COPY 0x7F4FD2EA
+
+typedef struct _COPY_HOOK_DATA {
+    wchar_t FileName[MAX_PATH];
+} COPY_HOOK_DATA, *PCOPY_HOOK_DATA;
+
+#endif

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
@@ -25,6 +25,10 @@
 
 #include "../GUI/ExtractRes.h"
 
+// **************** NanaZip Modification Start ****************
+#include "../Explorer/CopyHook.h"
+// **************** NanaZip Modification End ****************
+
 #include "resource.h"
 
 #include "App.h"
@@ -1138,6 +1142,40 @@ LRESULT CALLBACK WndProc(HWND hWnd, UINT message, WPARAM wParam, LPARAM lParam)
 
         break;
     }
+
+    // **************** NanaZip Modification Start ****************
+    case WM_COPYDATA:
+    {
+        PCOPYDATASTRUCT CopyDataStruct = reinterpret_cast<PCOPYDATASTRUCT>(
+            lParam);
+
+        if (CopyDataStruct->dwData == COPY_HOOK_COMMAND_COPY &&
+            CopyDataStruct->cbData == sizeof(COPY_HOOK_DATA))
+        {
+            CPanel& Panel = g_App.Panels[g_App.LastFocusedPanel];
+            PCOPY_HOOK_DATA Data = static_cast<PCOPY_HOOK_DATA>(
+                CopyDataStruct->lpData);
+            CCopyToOptions Options;
+
+            Options.folder = UString(Data->FileName);
+            Options.showErrorMessages = true;
+
+            CRecordVector<UInt32> Indices;
+            Panel.GetOperatedItemIndices(Indices);
+            if (Indices.Size() > 0)
+            {
+                HRESULT Result = Panel.CopyTo(Options, Indices, nullptr);
+
+                if (Result != S_OK && Result != E_ABORT)
+                {
+                    Panel.MessageBox_Error_HRESULT(Result);
+                }
+            }
+            return TRUE;
+        }
+        break;
+    }
+    // **************** NanaZip Modification End ****************
     default:
         break;
   }

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/PanelDrag.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/PanelDrag.cpp
@@ -319,6 +319,40 @@ static bool CopyNamesToHGlobal(NMemory::CGlobal &hgDrop, const UStringVector &na
   return true;
 }
 
+// **************** NanaZip Modification Start ****************
+static BOOL FastDragDropAvailable()
+{
+    if (!WantFastDragDrop())
+    {
+        return FALSE;
+    }
+
+    static TOKEN_ELEVATION_TYPE CachedElevation = ([]() -> TOKEN_ELEVATION_TYPE
+    {
+        TOKEN_ELEVATION_TYPE CurrentElevation;
+        DWORD Length = sizeof(CurrentElevation);
+        if (!GetTokenInformation(
+            GetCurrentProcessToken(),
+            TokenElevationType,
+            &CurrentElevation,
+            Length,
+            &Length))
+        {
+            // Fallback to disable
+            return TokenElevationTypeFull;
+        }
+        return CurrentElevation;
+    }());
+
+    if (CachedElevation == TokenElevationTypeFull)
+    {
+        return FALSE;
+    }
+
+    return TRUE;
+}
+// **************** NanaZip Modification End ****************
+
 void CPanel::OnDrag(LPNMLISTVIEW /* nmListView */)
 {
   if (!DoesItSupportOperations())
@@ -339,7 +373,7 @@ void CPanel::OnDrag(LPNMLISTVIEW /* nmListView */)
   CTempDir tempDirectory;
 
   // **************** NanaZip Modification Start ****************
-  bool FastDragDrop = WantFastDragDrop();
+  bool FastDragDrop = FastDragDropAvailable();
   FString FakeDirPath;
   // **************** NanaZip Modification End ****************
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.cpp
@@ -30,6 +30,9 @@ static LPCTSTR const kFullRow = TEXT("FullRow");
 static LPCTSTR const kShowGrid = TEXT("ShowGrid");
 static LPCTSTR const kSingleClick = TEXT("SingleClick");
 static LPCTSTR const kAlternativeSelection = TEXT("AlternativeSelection");
+// **************** NanaZip Modification Start ****************
+static LPCTSTR const FastDragDropSetting = TEXT("FastDragDrop");
+// **************** NanaZip Modification End ****************
 // static LPCTSTR const kUnderline = TEXT("Underline");
 
 static LPCTSTR const kShowSystemMenu = TEXT("ShowSystemMenu");
@@ -152,6 +155,9 @@ void CFmSettings::Save() const
   SaveOption(kCopyHistory, CopyHistory);
   SaveOption(kFolderHistory, FolderHistory);
   SaveOption(kLowercaseHashes, LowercaseHashes);
+  // **************** NanaZip Modification Start ****************
+  SaveOption(FastDragDropSetting, this->FastDragDrop);
+  // **************** NanaZip Modification End ****************
   // SaveOption(kUnderline, Underline);
 
   SaveOption(kShowSystemMenu, ShowSystemMenu);
@@ -170,6 +176,9 @@ void CFmSettings::Load()
   CopyHistory = false;
   FolderHistory = false;
   LowercaseHashes = false;
+  // **************** NanaZip Modification Start ****************
+  this->FastDragDrop = false;
+  // **************** NanaZip Modification End ****************
   // Underline = false;
 
   ShowSystemMenu = false;
@@ -188,6 +197,9 @@ void CFmSettings::Load()
     ReadOption(key, kCopyHistory, CopyHistory);
     ReadOption(key, kFolderHistory, FolderHistory);
     ReadOption(key, kLowercaseHashes, LowercaseHashes);
+    // **************** NanaZip Modification Start ****************
+    ReadOption(key, FastDragDropSetting, this->FastDragDrop);
+    // **************** NanaZip Modification End ****************
     // ReadOption(key, kUnderline, Underline);
 
     ReadOption(key, kShowSystemMenu, ShowSystemMenu );
@@ -206,6 +218,9 @@ bool WantPathHistory() { return ReadFMOption(kPathHistory); }
 bool WantCopyHistory() { return ReadFMOption(kCopyHistory); }
 bool WantFolderHistory() { return ReadFMOption(kFolderHistory); }
 bool WantLowercaseHashes() { return ReadFMOption(kLowercaseHashes); }
+// **************** NanaZip Modification Start ****************
+bool WantFastDragDrop() { return ReadFMOption(FastDragDropSetting); }
+// **************** NanaZip Modification End ****************
 
 static CSysString GetFlatViewName(UInt32 panelIndex)
 {

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.h
@@ -30,6 +30,9 @@ struct CFmSettings
   bool CopyHistory;
   bool FolderHistory;
   bool LowercaseHashes;
+  // **************** NanaZip Modification Start ****************
+  bool FastDragDrop;
+  // **************** NanaZip Modification End ****************
   // bool Underline;
 
   bool ShowSystemMenu;
@@ -49,6 +52,9 @@ bool WantPathHistory();
 bool WantCopyHistory();
 bool WantFolderHistory();
 bool WantLowercaseHashes();
+// **************** NanaZip Modification Start ****************
+bool WantFastDragDrop();
+// **************** NanaZip Modification End ****************
 
 void SaveFlatView(UInt32 panelIndex, bool enable);
 bool ReadFlatView(UInt32 panelIndex);

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPage.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPage.cpp
@@ -125,6 +125,9 @@ bool CSettingsPage::OnInit()
   CheckButton(IDX_SETTINGS_SHOW_GRID, st.ShowGrid);
   CheckButton(IDX_SETTINGS_SINGLE_CLICK, st.SingleClick);
   CheckButton(IDX_SETTINGS_ALTERNATIVE_SELECTION, st.AlternativeSelection);
+  // **************** NanaZip Modification Start ****************
+  CheckButton(IDX_SETTINGS_FAST_DRAG_DROP, st.FastDragDrop);
+  // **************** NanaZip Modification End ****************
   // CheckButton(IDX_SETTINGS_UNDERLINE, st.Underline);
 
   CheckButton(IDX_SETTINGS_SHOW_SYSTEM_MENU, st.ShowSystemMenu);
@@ -224,6 +227,9 @@ LONG CSettingsPage::OnApply()
     st.CopyHistory = IsButtonCheckedBool(IDX_SETTINGS_WANT_COPY_HISTORY);
     st.FolderHistory = IsButtonCheckedBool(IDX_SETTINGS_WANT_FOLDER_HISTORY);
     st.LowercaseHashes = IsButtonCheckedBool(IDX_SETTINGS_LOWERCASE_HASHES);
+    // **************** NanaZip Modification Start ****************
+    st.FastDragDrop = IsButtonCheckedBool(IDX_SETTINGS_FAST_DRAG_DROP);
+    // **************** NanaZip Modification End ****************
     // st.Underline = IsButtonCheckedBool(IDX_SETTINGS_UNDERLINE);
 
     st.ShowSystemMenu = IsButtonCheckedBool(IDX_SETTINGS_SHOW_SYSTEM_MENU);
@@ -341,6 +347,9 @@ bool CSettingsPage::OnButtonClicked(int buttonID, HWND buttonHWND)
     case IDX_SETTINGS_FULL_ROW:
     case IDX_SETTINGS_SHOW_GRID:
     case IDX_SETTINGS_ALTERNATIVE_SELECTION:
+    // **************** NanaZip Modification Start ****************
+    case IDX_SETTINGS_FAST_DRAG_DROP:
+    // **************** NanaZip Modification End ****************
     case IDX_SETTINGS_WANT_ARC_HISTORY:
     case IDX_SETTINGS_WANT_PATH_HISTORY:
     case IDX_SETTINGS_WANT_COPY_HISTORY:

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPage2.rc
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPage2.rc
@@ -18,6 +18,8 @@ BEGIN
   CONTROL  "Want CopyHistory",   IDX_SETTINGS_WANT_COPY_HISTORY,      MY_CHECKBOX, m, 168, xc, 10
   CONTROL  "Want FolderHistory", IDX_SETTINGS_WANT_FOLDER_HISTORY,    MY_CHECKBOX, m, 182, xc, 10
   CONTROL  "Use Lowercase Hashes", IDX_SETTINGS_LOWERCASE_HASHES,     MY_CHECKBOX, m, 196, xc, 10
+
+  CONTROL  "Use fast drag-and-drop", IDX_SETTINGS_FAST_DRAG_DROP,     MY_CHECKBOX, m, 214, xc, 10
   // **************** NanaZip Modification End ****************
 
   // LTEXT     "Memory usage for Compressing:", IDT_COMPRESS_MEMORY, m, 140, xc, 8

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPageRes.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPageRes.h
@@ -14,6 +14,9 @@
 #define IDX_SETTINGS_WANT_COPY_HISTORY      2511
 #define IDX_SETTINGS_WANT_FOLDER_HISTORY    2512
 #define IDX_SETTINGS_LOWERCASE_HASHES       2513
+// **************** NanaZip Modification Start ****************
+#define IDX_SETTINGS_FAST_DRAG_DROP         2515
+// **************** NanaZip Modification End ****************
 
 
 // #define IDT_SETTINGS_MEM     100

--- a/NanaZipPackage/Strings/en/Legacy.resw
+++ b/NanaZipPackage/Strings/en/Legacy.resw
@@ -666,6 +666,9 @@
   <data name="Resource2513" xml:space="preserve">
     <value>Use Lowercase Hashes</value>
   </data>
+  <data name="Resource2515" xml:space="preserve">
+    <value>Use fast drag-and-drop</value>
+  </data>
   <data name="Resource2900" xml:space="preserve">
     <value>About NanaZip</value>
   </data>


### PR DESCRIPTION
fixes #353, fixes #371

Provides fast drag-to-extract support for NanaZip FM.
If the feature is enabled, dragging from the main window creates a directory with the name `{<COPYHOOK_GUID>}.<HWND>`.
Directories with this name are intercepted by an external copy hook shell extension NanaZip.Extras.ShellExtension, which sends back a WM_COPYDATA message containing the destination drop path.
Upon reception of WM_COPYDATA, NanaZip extracts selected files into the destination directory.

Todo list:

- [x] Decide on a shell extension distribution method for NanaZip.Extras. (via separate MSI)
- [x] Integrate shell extensions into the project.
- [x] Convert shell extension registration to SelfReg
- [ ] Find a fallback extraction method when shell extension is not present.
- [x] Build script integration?

Feedback is welcome.