### PR TITLE
Always split path in CExtractDialog.

### DIFF
--- a/NanaZip.Core/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.cpp
@@ -192,19 +192,31 @@ bool CExtractDialog::OnInit()
   UString pathPrefix = DirPath;
 
   #ifndef Z7_SFX
-  
+
+  // **************** NanaZip Modification Start ****************
+  UString pathName;
+  SplitPathToParts_Smart(DirPath, pathPrefix, pathName);
+  if (pathPrefix.IsEmpty())
+    pathPrefix = pathName;
+  else
+    _pathName.SetText(pathName);
+
+  //if (_info.SplitDest.Val)
+  //{
+  //  CheckButton(IDX_EXTRACT_NAME_ENABLE, true);
+  //  UString pathName;
+  //  SplitPathToParts_Smart(DirPath, pathPrefix, pathName);
+  //  if (pathPrefix.IsEmpty())
+  //    pathPrefix = pathName;
+  //  else
+  //    _pathName.SetText(pathName);
+  //}
+
   if (_info.SplitDest.Val)
-  {
     CheckButton(IDX_EXTRACT_NAME_ENABLE, true);
-    UString pathName;
-    SplitPathToParts_Smart(DirPath, pathPrefix, pathName);
-    if (pathPrefix.IsEmpty())
-      pathPrefix = pathName;
-    else
-      _pathName.SetText(pathName);
-  }
   else
     ShowItem_Bool(IDE_EXTRACT_NAME, false);
+  // **************** NanaZip Modification End ****************
 
   #endif
 

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.cpp
@@ -188,18 +188,30 @@ bool CExtractDialog::OnInit()
 
   #ifndef _SFX
 
+  // **************** NanaZip Modification Start ****************
+  UString pathName;
+  SplitPathToParts_Smart(DirPath, pathPrefix, pathName);
+  if (pathPrefix.IsEmpty())
+    pathPrefix = pathName;
+  else
+    _pathName.SetText(pathName);
+
+  //if (_info.SplitDest.Val)
+  //{
+  //  CheckButton(IDX_EXTRACT_NAME_ENABLE, true);
+  //  UString pathName;
+  //  SplitPathToParts_Smart(DirPath, pathPrefix, pathName);
+  //  if (pathPrefix.IsEmpty())
+  //    pathPrefix = pathName;
+  //  else
+  //    _pathName.SetText(pathName);
+  //}
+
   if (_info.SplitDest.Val)
-  {
     CheckButton(IDX_EXTRACT_NAME_ENABLE, true);
-    UString pathName;
-    SplitPathToParts_Smart(DirPath, pathPrefix, pathName);
-    if (pathPrefix.IsEmpty())
-      pathPrefix = pathName;
-    else
-      _pathName.SetText(pathName);
-  }
   else
     ShowItem_Bool(IDE_EXTRACT_NAME, false);
+  // **************** NanaZip Modification End ****************
 
   #endif
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.cpp
@@ -188,18 +188,30 @@ bool CExtractDialog::OnInit()
 
   #ifndef _SFX
 
+  // **************** NanaZip Modification Start ****************
+  UString pathName;
+  SplitPathToParts_Smart(DirPath, pathPrefix, pathName);
+  if (pathPrefix.IsEmpty())
+    pathPrefix = pathName;
+  else
+    _pathName.SetText(pathName);
+
+  //if (_info.SplitDest.Val)
+  //{
+  //  CheckButton(IDX_EXTRACT_NAME_ENABLE, true);
+  //  UString pathName;
+  //  SplitPathToParts_Smart(DirPath, pathPrefix, pathName);
+  //  if (pathPrefix.IsEmpty())
+  //    pathPrefix = pathName;
+  //  else
+  //    _pathName.SetText(pathName);
+  //}
+
   if (_info.SplitDest.Val)
-  {
     CheckButton(IDX_EXTRACT_NAME_ENABLE, true);
-    UString pathName;
-    SplitPathToParts_Smart(DirPath, pathPrefix, pathName);
-    if (pathPrefix.IsEmpty())
-      pathPrefix = pathName;
-    else
-      _pathName.SetText(pathName);
-  }
   else
     ShowItem_Bool(IDE_EXTRACT_NAME, false);
+  // **************** NanaZip Modification End ****************
 
   #endif
 


### PR DESCRIPTION
Even if the archive name checkbox in CExtractDialog is not checked, NanaZip appends the archive name to its extraction path anyway. Fix this issue by always splitting the extraction path in NanaZip.Windows.