### PR TITLE
修复#457的补丁

### DIFF
--- a/NanaZip.Core/SevenZip/CPP/7zip/UI/FileManager/LangUtils.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/UI/FileManager/LangUtils.cpp
@@ -77,7 +77,6 @@ static const CIDLangPair kLangPairs[] =
   { IDYES,    406 },
   { IDNO,     407 },
   { IDCLOSE,  408 },
-  { IDHELP,   409 },
   { IDCONTINUE, 411 }
 };
 

--- a/NanaZip.Core/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.rc
+++ b/NanaZip.Core/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.rc
@@ -54,9 +54,8 @@ BEGIN
   CONTROL   "Restore file security", IDX_EXTRACT_NT_SECUR, MY_CHECKBOX,
             g2x, m + 104, g2xs, 10
   
-  DEFPUSHBUTTON  "OK",     IDOK,     bx3, by, bxs, bys, WS_GROUP
-  PUSHBUTTON     "Cancel", IDCANCEL, bx2, by, bxs, bys
-  PUSHBUTTON     "Help",   IDHELP,   bx1, by, bxs, bys
+  DEFPUSHBUTTON  "OK",     IDOK,     bx2, by, bxs, bys, WS_GROUP
+  PUSHBUTTON     "Cancel", IDCANCEL, bx1, by, bxs, bys
 END
 
 

--- a/NanaZip.Core/SevenZip/CPP/Windows/Control/Dialog.cpp
+++ b/NanaZip.Core/SevenZip/CPP/Windows/Control/Dialog.cpp
@@ -94,7 +94,6 @@ bool CDialog::OnButtonClicked(unsigned buttonID, HWND /* buttonHWND */)
     case IDCANCEL: OnCancel(); break;
     case IDCLOSE: OnClose(); break;
     case IDCONTINUE: OnContinue(); break;
-    case IDHELP: OnHelp(); break;
     default: return false;
   }
   return true;

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/CompressDialog.rc
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/CompressDialog.rc
@@ -132,9 +132,8 @@ BEGIN
   CONTROL   "Encrypt file &names", IDX_COMPRESS_ENCRYPT_FILE_NAMES, MY_CHECKBOX,
             g4x2, yPsw + 111, g4xs2, 10
   
-  DEFPUSHBUTTON  "OK",     IDOK,     bx3, by, bxs, bys, WS_GROUP
-  PUSHBUTTON     "Cancel", IDCANCEL, bx2, by, bxs, bys
-  PUSHBUTTON     "Help",   IDHELP,   bx1, by, bxs, bys
+  DEFPUSHBUTTON  "OK",     IDOK,     bx2, by, bxs, bys, WS_GROUP
+  PUSHBUTTON     "Cancel", IDCANCEL, bx1, by, bxs, bys
 END
 
 

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/CompressOptionsDialog.rc
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/CompressOptionsDialog.rc
@@ -70,7 +70,6 @@ BEGIN
             ntPosX, timePosY + 92, ntSizeX, 16
   
   
-  DEFPUSHBUTTON  "OK",     IDOK,     bx3, by, bxs, bys, WS_GROUP
-  PUSHBUTTON     "Cancel", IDCANCEL, bx2, by, bxs, bys
-  PUSHBUTTON     "Help",   IDHELP,   bx1, by, bxs, bys
+  DEFPUSHBUTTON  "OK",     IDOK,     bx2, by, bxs, bys, WS_GROUP
+  PUSHBUTTON     "Cancel", IDCANCEL, bx1, by, bxs, bys
 END

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/CompressDialog.rc
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/CompressDialog.rc
@@ -132,9 +132,8 @@ BEGIN
   CONTROL   "Encrypt file &names", IDX_COMPRESS_ENCRYPT_FILE_NAMES, MY_CHECKBOX,
             g4x2, yPsw + 111, g4xs2, 10
   
-  DEFPUSHBUTTON  "OK",     IDOK,     bx3, by, bxs, bys, WS_GROUP
-  PUSHBUTTON     "Cancel", IDCANCEL, bx2, by, bxs, bys
-  PUSHBUTTON     "Help",   IDHELP,   bx1, by, bxs, bys
+  DEFPUSHBUTTON  "OK",     IDOK,     bx2, by, bxs, bys, WS_GROUP
+  PUSHBUTTON     "Cancel", IDCANCEL, bx1, by, bxs, bys
 END
 
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/CompressOptionsDialog.rc
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/CompressOptionsDialog.rc
@@ -70,7 +70,6 @@ BEGIN
             ntPosX, timePosY + 92, ntSizeX, 16
   
   
-  DEFPUSHBUTTON  "OK",     IDOK,     bx3, by, bxs, bys, WS_GROUP
-  PUSHBUTTON     "Cancel", IDCANCEL, bx2, by, bxs, bys
-  PUSHBUTTON     "Help",   IDHELP,   bx1, by, bxs, bys
+  DEFPUSHBUTTON  "OK",     IDOK,     bx2, by, bxs, bys, WS_GROUP
+  PUSHBUTTON     "Cancel", IDCANCEL, bx1, by, bxs, bys
 END


### PR DESCRIPTION
修补两个cpp和五个rc文件修复#457，同时让nanazip更现代化

我修补的文件：

![我修补的文件列表](https://github.com/user-attachments/assets/80e38ede-d5d7-4f78-b34f-a1251ae5075f)

修补之后的效果：

![修补之后的效果](https://github.com/user-attachments/assets/d22aa8c5-dffb-4f2b-b5a4-e228a5c77f79)
