### PR TITLE
Modern: bring dialogs to foreground

### DIFF
--- a/NanaZip.UI.Modern/SevenZip/CPP/Windows/Control/Dialog.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/Windows/Control/Dialog.cpp
@@ -26,8 +26,10 @@ static INT_PTR APIENTRY DialogProcedure(HWND dialogHWND, UINT message, WPARAM wP
   CDialog *dialog = (CDialog *)(tempDialog.GetUserDataLongPtr());
   if (dialog == NULL)
     return FALSE;
-  if (message == WM_INITDIALOG)
+  if (message == WM_INITDIALOG) {
     dialog->Attach(dialogHWND);
+    BringToForeground(dialogHWND, 0);
+  }
 
   /* MSDN: The dialog box procedure should return
        TRUE  - if it processed the message

--- a/NanaZip.UI.Modern/SevenZip/CPP/Windows/ProcessUtils.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/Windows/ProcessUtils.cpp
@@ -5,60 +5,11 @@
 #include "../Common/StringConvert.h"
 
 #include "ProcessUtils.h"
+#include "Window.h"
 
 #ifndef _UNICODE
 extern bool g_IsNT;
 #endif
-
-// **************** NanaZip Modification Start ****************
-static BOOL CALLBACK BringToForeground(
-    _In_ HWND hWnd,
-    _In_ LPARAM lParam)
-{
-    DWORD ProcessId;
-    ::GetWindowThreadProcessId(hWnd, &ProcessId);
-
-    if (ProcessId == (DWORD)lParam)
-    {
-        HWND ForegroundWindowHandle = ::GetForegroundWindow();
-        DWORD CurrentThreadId = ::GetCurrentThreadId();
-        DWORD CurrentWindowThreadId = ::GetWindowThreadProcessId(
-            ForegroundWindowHandle,
-            nullptr);
-        ::AttachThreadInput(
-            CurrentWindowThreadId,
-            CurrentThreadId,
-            TRUE);
-        ::SetWindowPos(
-            hWnd,
-            HWND_TOPMOST,
-            0,
-            0,
-            0,
-            0,
-            SWP_NOSIZE | SWP_NOMOVE);
-        ::SetWindowPos(
-            hWnd,
-            HWND_NOTOPMOST,
-            0,
-            0,
-            0,
-            0,
-            SWP_SHOWWINDOW | SWP_NOSIZE | SWP_NOMOVE);
-        ::SetForegroundWindow(hWnd);
-        ::SetFocus(hWnd);
-        ::SetActiveWindow(hWnd);
-        ::AttachThreadInput(
-            CurrentWindowThreadId,
-            CurrentThreadId,
-            FALSE);
-
-        return FALSE;
-    }
-
-    return TRUE;
-}
-// **************** NanaZip Modification End ****************
 
 namespace NWindows {
 
@@ -113,7 +64,7 @@ WRes CProcess::Create(LPCWSTR imageName, const UString &params, LPCWSTR curDir)
     si.dwFlags = 0;
     si.cbReserved2 = 0;
     si.lpReserved2 = 0;
-    
+
     CSysString curDirA;
     if (curDir != 0)
       curDirA = GetSystemString(curDir);
@@ -132,7 +83,7 @@ WRes CProcess::Create(LPCWSTR imageName, const UString &params, LPCWSTR curDir)
     si.dwFlags = 0;
     si.cbReserved2 = 0;
     si.lpReserved2 = 0;
-    
+
     result = CreateProcessW(imageName, params2.Ptr_non_const(),
         NULL, NULL, FALSE, 0, NULL, curDir, &si, &pi);
   }
@@ -143,7 +94,7 @@ WRes CProcess::Create(LPCWSTR imageName, const UString &params, LPCWSTR curDir)
   ::AllowSetForegroundWindow(GetProcessId(pi.hProcess));
   ::WaitForInputIdle(pi.hProcess, 500);
   ::EnumWindows(
-      ::BringToForeground,
+      BringToForeground,
       static_cast<LPARAM>(::GetProcessId(pi.hProcess)));
   // **************** NanaZip Modification End ****************
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/Windows/Window.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/Windows/Window.cpp
@@ -13,6 +13,56 @@ extern bool g_IsNT;
 
 namespace NWindows {
 
+// **************** NanaZip Modification Start ****************
+BOOL CALLBACK BringToForeground(
+    _In_ HWND hWnd,
+    _In_ LPARAM lParam)
+{
+    DWORD ProcessId = 0;
+    ::GetWindowThreadProcessId(hWnd, &ProcessId);
+
+    if (!lParam || ProcessId == (DWORD)lParam)
+    {
+        HWND ForegroundWindowHandle = ::GetForegroundWindow();
+        DWORD CurrentThreadId = ::GetCurrentThreadId();
+        DWORD ForegroundThreadId = ::GetWindowThreadProcessId(
+            ForegroundWindowHandle,
+            nullptr);
+        ::AttachThreadInput(
+            ForegroundThreadId,
+            CurrentThreadId,
+            TRUE);
+        ::SetWindowPos(
+            hWnd,
+            HWND_TOPMOST,
+            0,
+            0,
+            0,
+            0,
+            SWP_NOSIZE | SWP_NOMOVE);
+        ::SetWindowPos(
+            hWnd,
+            HWND_NOTOPMOST,
+            0,
+            0,
+            0,
+            0,
+            SWP_SHOWWINDOW | SWP_NOSIZE | SWP_NOMOVE);
+        ::SetForegroundWindow(hWnd);
+        ::SetFocus(hWnd);
+        ::SetActiveWindow(hWnd);
+        ::AttachThreadInput(
+            ForegroundThreadId,
+            CurrentThreadId,
+            FALSE);
+
+        return FALSE;
+    }
+
+    return TRUE;
+}
+// **************** NanaZip Modification End ****************
+
 #ifndef _UNICODE
 ATOM MyRegisterClass(CONST WNDCLASSW *wndClass)
 {
@@ -156,7 +206,7 @@ bool CWindow::GetText(UString &s)
 }
 #endif
 
- 
+
 /*
 bool CWindow::ModifyStyleBase(int styleOffset,
   DWORD remove, DWORD add, UINT flags)

--- a/NanaZip.UI.Modern/SevenZip/CPP/Windows/Window.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/Windows/Window.h
@@ -28,6 +28,12 @@
 
 namespace NWindows {
 
+// **************** NanaZip Modification Start ****************
+BOOL CALLBACK BringToForeground(
+    _In_ HWND hWnd,
+    _In_ LPARAM lParam);
+// **************** NanaZip Modification End ****************
+
 inline ATOM MyRegisterClass(CONST WNDCLASS *wndClass)
   { return ::RegisterClass(wndClass); }
 
@@ -73,7 +79,7 @@ public:
   }
 
   bool Foreground() { return BOOLToBool(::SetForegroundWindow(_window)); }
-  
+
   HWND GetParent() const { return ::GetParent(_window); }
   bool GetWindowRect(LPRECT rect) const { return BOOLToBool(::GetWindowRect(_window,rect)); }
   #ifndef UNDER_CE
@@ -190,9 +196,9 @@ public:
 
   LONG_PTR SetUserDataLongPtr(LONG_PTR newLongPtr) { return SetUserDataLong(newLongPtr); }
   LONG_PTR GetUserDataLongPtr() const { return GetUserDataLong(); }
-  
+
   #else
-  
+
   LONG_PTR SetLongPtr(int index, LONG_PTR newLongPtr)
     { return ::SetWindowLongPtr(_window, index,
           #ifndef _WIN64
@@ -211,16 +217,16 @@ public:
   LONG_PTR GetLongPtr(int index) const { return ::GetWindowLongPtr(_window, index); }
   LONG_PTR SetUserDataLongPtr(LONG_PTR newLongPtr) { return SetLongPtr(GWLP_USERDATA, newLongPtr); }
   LONG_PTR GetUserDataLongPtr() const { return GetLongPtr(GWLP_USERDATA); }
-  
+
   #endif
-  
+
   /*
   bool ModifyStyle(HWND hWnd, DWORD remove, DWORD add, UINT flags = 0)
     {  return ModifyStyleBase(GWL_STYLE, remove, add, flags); }
   bool ModifyStyleEx(HWND hWnd, DWORD remove, DWORD add, UINT flags = 0)
     { return ModifyStyleBase(GWL_EXSTYLE, remove, add, flags); }
   */
- 
+
   HWND SetFocus() { return ::SetFocus(_window); }
 
   LRESULT SendMsg(UINT message, WPARAM wParam = 0, LPARAM lParam = 0)
@@ -257,10 +263,10 @@ public:
 
   bool Enable(bool enable)
     { return BOOLToBool(::EnableWindow(_window, BoolToBOOL(enable))); }
-  
+
   bool IsEnabled()
     { return BOOLToBool(::IsWindowEnabled(_window)); }
-  
+
   #ifndef UNDER_CE
   HMENU GetSystemMenu(bool revert)
     { return ::GetSystemMenu(_window, BoolToBOOL(revert)); }


### PR DESCRIPTION
Call `BringToForeground` every time a dialog is created to make sure that dialogs don't get lost in the background.

Also move `BringToForeground` to `Window.cpp`.