### PR TITLE
Move open folder checkbox to extract dialog.

### DIFF
--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/Extract.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/Extract.h
@@ -49,6 +49,9 @@ struct CExtractOptions: public CExtractOptionsBase
 {
   bool StdInMode;
   bool StdOutMode;
+  // **************** NanaZip Modification Start ****************
+  CBoolPair OpenFolder;
+  // **************** NanaZip Modification End ****************
   bool YesToAll;
   bool TestMode;
 

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
@@ -99,6 +99,9 @@ static LPCTSTR const kSplitDest = TEXT("SplitDest");
 static LPCTSTR const kElimDup = TEXT("ElimDup");
 // static LPCTSTR const kAltStreams = TEXT("AltStreams");
 static LPCTSTR const kNtSecur = TEXT("Security");
+// **************** NanaZip Modification Start ****************
+static LPCTSTR const kOpenFolderAfterExtract = TEXT("OpenFolderAfterExtract");
+// **************** NanaZip Modification End ****************
 
 void CInfo::Save() const
 {
@@ -117,6 +120,9 @@ void CInfo::Save() const
   // Key_Set_BoolPair(key, kAltStreams, AltStreams);
   Key_Set_BoolPair(key, kNtSecur, NtSecurity);
   Key_Set_BoolPair(key, kShowPassword, ShowPassword);
+  // **************** NanaZip Modification Start ****************
+  Key_Set_BoolPair(key, kOpenFolderAfterExtract, OpenFolder);
+  // **************** NanaZip Modification End ****************
 
   key.RecurseDeleteKey(kPathHistory);
   if (WantPathHistory())
@@ -168,6 +174,9 @@ void CInfo::Load()
   // Key_Get_BoolPair(key, kAltStreams, AltStreams);
   Key_Get_BoolPair(key, kNtSecur, NtSecurity);
   Key_Get_BoolPair(key, kShowPassword, ShowPassword);
+  // **************** NanaZip Modification Start ****************
+  Key_Get_BoolPair(key, kOpenFolderAfterExtract, OpenFolder);
+  // **************** NanaZip Modification End ****************
 }
 
 bool Read_ShowPassword()

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ZipRegistry.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ZipRegistry.h
@@ -34,6 +34,9 @@ namespace NExtract
     // CBoolPair AltStreams;
     CBoolPair NtSecurity;
     CBoolPair ShowPassword;
+    // **************** NanaZip Modification Start ****************
+    CBoolPair OpenFolder;
+    // **************** NanaZip Modification End ****************
 
     UStringVector Paths;
 

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.cpp
@@ -30,9 +30,6 @@ static LPCTSTR const kFullRow = TEXT("FullRow");
 static LPCTSTR const kShowGrid = TEXT("ShowGrid");
 static LPCTSTR const kSingleClick = TEXT("SingleClick");
 static LPCTSTR const kAlternativeSelection = TEXT("AlternativeSelection");
-// **************** NanaZip Modification Start ****************
-static LPCTSTR const kOpenFolderAfterExtract = TEXT("OpenFolderAfterExtract");
-// **************** NanaZip Modification End ****************
 // static LPCTSTR const kUnderline = TEXT("Underline");
 
 static LPCTSTR const kShowSystemMenu = TEXT("ShowSystemMenu");
@@ -155,9 +152,6 @@ void CFmSettings::Save() const
   SaveOption(kCopyHistory, CopyHistory);
   SaveOption(kFolderHistory, FolderHistory);
   SaveOption(kLowercaseHashes, LowercaseHashes);
-  // **************** NanaZip Modification Start ****************
-  SaveOption(kOpenFolderAfterExtract, OpenFolderAfterExtract);
-  // **************** NanaZip Modification End ****************
   // SaveOption(kUnderline, Underline);
 
   SaveOption(kShowSystemMenu, ShowSystemMenu);
@@ -176,7 +170,6 @@ void CFmSettings::Load()
   CopyHistory = false;
   FolderHistory = false;
   LowercaseHashes = false;
-  OpenFolderAfterExtract = false;
   // Underline = false;
 
   ShowSystemMenu = false;
@@ -195,9 +188,6 @@ void CFmSettings::Load()
     ReadOption(key, kCopyHistory, CopyHistory);
     ReadOption(key, kFolderHistory, FolderHistory);
     ReadOption(key, kLowercaseHashes, LowercaseHashes);
-    // **************** NanaZip Modification Start ****************
-    ReadOption(key, kOpenFolderAfterExtract, OpenFolderAfterExtract);
-    // **************** NanaZip Modification End ****************
     // ReadOption(key, kUnderline, Underline);
 
     ReadOption(key, kShowSystemMenu, ShowSystemMenu );
@@ -216,9 +206,6 @@ bool WantPathHistory() { return ReadFMOption(kPathHistory); }
 bool WantCopyHistory() { return ReadFMOption(kCopyHistory); }
 bool WantFolderHistory() { return ReadFMOption(kFolderHistory); }
 bool WantLowercaseHashes() { return ReadFMOption(kLowercaseHashes); }
-// **************** NanaZip Modification Start ****************
-bool WantOpenFolderAfterExtract() { return ReadFMOption(kOpenFolderAfterExtract); }
-// **************** NanaZip Modification End ****************
 
 static CSysString GetFlatViewName(UInt32 panelIndex)
 {

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.h
@@ -30,9 +30,6 @@ struct CFmSettings
   bool CopyHistory;
   bool FolderHistory;
   bool LowercaseHashes;
-  // **************** NanaZip Modification Start ****************
-  bool OpenFolderAfterExtract;
-  // **************** NanaZip Modification End ****************
   // bool Underline;
 
   bool ShowSystemMenu;
@@ -52,9 +49,6 @@ bool WantPathHistory();
 bool WantCopyHistory();
 bool WantFolderHistory();
 bool WantLowercaseHashes();
-// **************** NanaZip Modification Start ****************
-bool WantOpenFolderAfterExtract();
-// **************** NanaZip Modification End ****************
 
 void SaveFlatView(UInt32 panelIndex, bool enable);
 bool ReadFlatView(UInt32 panelIndex);

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPage.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPage.cpp
@@ -34,9 +34,6 @@ static const UInt32 kLangIDs[] =
   IDX_SETTINGS_WANT_COPY_HISTORY,
   IDX_SETTINGS_WANT_FOLDER_HISTORY,
   IDX_SETTINGS_LOWERCASE_HASHES,
-  // **************** NanaZip Modification Start ****************
-  IDX_SETTINGS_OPEN_FOLDER_AFTER
-  // **************** NanaZip Modification End ****************
   // , IDT_COMPRESS_MEMORY
 };
 
@@ -128,9 +125,6 @@ bool CSettingsPage::OnInit()
   CheckButton(IDX_SETTINGS_SHOW_GRID, st.ShowGrid);
   CheckButton(IDX_SETTINGS_SINGLE_CLICK, st.SingleClick);
   CheckButton(IDX_SETTINGS_ALTERNATIVE_SELECTION, st.AlternativeSelection);
-  // **************** NanaZip Modification Start ****************
-  CheckButton(IDX_SETTINGS_OPEN_FOLDER_AFTER, st.OpenFolderAfterExtract);
-  // **************** NanaZip Modification End ****************
   // CheckButton(IDX_SETTINGS_UNDERLINE, st.Underline);
 
   CheckButton(IDX_SETTINGS_SHOW_SYSTEM_MENU, st.ShowSystemMenu);
@@ -230,9 +224,6 @@ LONG CSettingsPage::OnApply()
     st.CopyHistory = IsButtonCheckedBool(IDX_SETTINGS_WANT_COPY_HISTORY);
     st.FolderHistory = IsButtonCheckedBool(IDX_SETTINGS_WANT_FOLDER_HISTORY);
     st.LowercaseHashes = IsButtonCheckedBool(IDX_SETTINGS_LOWERCASE_HASHES);
-    // **************** NanaZip Modification Start ****************
-    st.OpenFolderAfterExtract = IsButtonCheckedBool(IDX_SETTINGS_OPEN_FOLDER_AFTER);
-    // **************** NanaZip Modification End ****************
     // st.Underline = IsButtonCheckedBool(IDX_SETTINGS_UNDERLINE);
 
     st.ShowSystemMenu = IsButtonCheckedBool(IDX_SETTINGS_SHOW_SYSTEM_MENU);
@@ -350,9 +341,6 @@ bool CSettingsPage::OnButtonClicked(int buttonID, HWND buttonHWND)
     case IDX_SETTINGS_FULL_ROW:
     case IDX_SETTINGS_SHOW_GRID:
     case IDX_SETTINGS_ALTERNATIVE_SELECTION:
-    // **************** NanaZip Modification Start ****************
-    case IDX_SETTINGS_OPEN_FOLDER_AFTER:
-    // **************** NanaZip Modification End ****************
     case IDX_SETTINGS_WANT_ARC_HISTORY:
     case IDX_SETTINGS_WANT_PATH_HISTORY:
     case IDX_SETTINGS_WANT_COPY_HISTORY:

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPage2.rc
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPage2.rc
@@ -1,36 +1,23 @@
 // #define g1xs 60
 
 CAPTION "Settings"
-BEGIN 
+BEGIN
   CONTROL  "Show "".."" item",      IDX_SETTINGS_SHOW_DOTS,            MY_CHECKBOX, m,  8, xc, 10
   CONTROL  "Show real file &icons", IDX_SETTINGS_SHOW_REAL_FILE_ICONS, MY_CHECKBOX, m, 22, xc, 10
   CONTROL  "&Full row select",      IDX_SETTINGS_FULL_ROW,             MY_CHECKBOX, m, 36, xc, 10
   CONTROL  "Show &grid lines",      IDX_SETTINGS_SHOW_GRID,            MY_CHECKBOX, m, 50, xc, 10
   CONTROL  "&Single-click to open an item", IDX_SETTINGS_SINGLE_CLICK, MY_CHECKBOX, m, 64, xc, 10
   CONTROL  "&Alternative selection mode", IDX_SETTINGS_ALTERNATIVE_SELECTION, MY_CHECKBOX, m, 78, xc, 10
+
+  CONTROL  "Show system &menu",     IDX_SETTINGS_SHOW_SYSTEM_MENU,     MY_CHECKBOX, m, 100, xc, 10
+  CONTROL  "Use &large memory pages", IDX_SETTINGS_LARGE_PAGES,        MY_CHECKBOX, m, 122, xc, 10
+
   // **************** NanaZip Modification Start ****************
-	
-  // CONTROL  "Show system &menu",     IDX_SETTINGS_SHOW_SYSTEM_MENU,     MY_CHECKBOX, m, 100, xc, 10
-  // CONTROL  "Use &large memory pages", IDX_SETTINGS_LARGE_PAGES,        MY_CHECKBOX, m, 122, xc, 10
-
-  // CONTROL  "Want ArcHistory",    IDX_SETTINGS_WANT_ARC_HISTORY,       MY_CHECKBOX, m, 140, xc, 10
-  // CONTROL  "Want PathHistory",   IDX_SETTINGS_WANT_PATH_HISTORY,      MY_CHECKBOX, m, 154, xc, 10
-  // CONTROL  "Want CopyHistory",   IDX_SETTINGS_WANT_COPY_HISTORY,      MY_CHECKBOX, m, 168, xc, 10
-  // CONTROL  "Want FolderHistory", IDX_SETTINGS_WANT_FOLDER_HISTORY,    MY_CHECKBOX, m, 182, xc, 10
-  // CONTROL  "Use Lowercase Hashes", IDX_SETTINGS_LOWERCASE_HASHES,     MY_CHECKBOX, m, 196, xc, 10
-	
-  
-  CONTROL  "&Open folder after extract", IDX_SETTINGS_OPEN_FOLDER_AFTER, MY_CHECKBOX, m, 92, xc, 10
-
-  CONTROL  "Show system &menu",     IDX_SETTINGS_SHOW_SYSTEM_MENU,     MY_CHECKBOX, m, 114, xc, 10
-
-  CONTROL  "Use &large memory pages", IDX_SETTINGS_LARGE_PAGES,        MY_CHECKBOX, m, 136, xc, 10
-
-  CONTROL  "Want ArcHistory",    IDX_SETTINGS_WANT_ARC_HISTORY,       MY_CHECKBOX, m, 154, xc, 10
-  CONTROL  "Want PathHistory",   IDX_SETTINGS_WANT_PATH_HISTORY,      MY_CHECKBOX, m, 168, xc, 10
-  CONTROL  "Want CopyHistory",   IDX_SETTINGS_WANT_COPY_HISTORY,      MY_CHECKBOX, m, 182, xc, 10
-  CONTROL  "Want FolderHistory", IDX_SETTINGS_WANT_FOLDER_HISTORY,    MY_CHECKBOX, m, 196, xc, 10
-  CONTROL  "Use Lowercase Hashes", IDX_SETTINGS_LOWERCASE_HASHES,     MY_CHECKBOX, m, 220, xc, 10
+  CONTROL  "Want ArcHistory",    IDX_SETTINGS_WANT_ARC_HISTORY,       MY_CHECKBOX, m, 140, xc, 10
+  CONTROL  "Want PathHistory",   IDX_SETTINGS_WANT_PATH_HISTORY,      MY_CHECKBOX, m, 154, xc, 10
+  CONTROL  "Want CopyHistory",   IDX_SETTINGS_WANT_COPY_HISTORY,      MY_CHECKBOX, m, 168, xc, 10
+  CONTROL  "Want FolderHistory", IDX_SETTINGS_WANT_FOLDER_HISTORY,    MY_CHECKBOX, m, 182, xc, 10
+  CONTROL  "Use Lowercase Hashes", IDX_SETTINGS_LOWERCASE_HASHES,     MY_CHECKBOX, m, 196, xc, 10
   // **************** NanaZip Modification End ****************
 
   // LTEXT     "Memory usage for Compressing:", IDT_COMPRESS_MEMORY, m, 140, xc, 8

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPageRes.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/SettingsPageRes.h
@@ -14,9 +14,6 @@
 #define IDX_SETTINGS_WANT_COPY_HISTORY      2511
 #define IDX_SETTINGS_WANT_FOLDER_HISTORY    2512
 #define IDX_SETTINGS_LOWERCASE_HASHES       2513
-// **************** NanaZip Modification Start ****************
-#define IDX_SETTINGS_OPEN_FOLDER_AFTER       2514 
-// **************** NanaZip Modification End ****************
 
 
 // #define IDT_SETTINGS_MEM     100

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.cpp
@@ -75,6 +75,9 @@ static const UInt32 kLangIDs[] =
   // IDX_EXTRACT_ALT_STREAMS,
   IDX_EXTRACT_NT_SECUR,
   IDX_EXTRACT_ELIM_DUP,
+  // **************** NanaZip Modification Start ****************
+  IDX_EXTRACT_OPEN_FOLDER,
+  // **************** NanaZip Modification End ****************
   IDG_PASSWORD,
   IDX_PASSWORD_SHOW
 };
@@ -176,6 +179,9 @@ bool CExtractDialog::OnInit()
   // CheckButton_TwoBools(IDX_EXTRACT_ALT_STREAMS, AltStreams, _info.AltStreams);
   CheckButton_TwoBools(IDX_EXTRACT_NT_SECUR,    NtSecurity, _info.NtSecurity);
   CheckButton_TwoBools(IDX_EXTRACT_ELIM_DUP,    ElimDup,    _info.ElimDup);
+  // **************** NanaZip Modification Start ****************
+  CheckButton_TwoBools(IDX_EXTRACT_OPEN_FOLDER, OpenFolder, _info.OpenFolder);
+  // **************** NanaZip Modification End ****************
 
   CheckButton(IDX_PASSWORD_SHOW, _info.ShowPassword.Val);
   UpdatePasswordControl();
@@ -325,6 +331,9 @@ void CExtractDialog::OnOK()
   // GetButton_Bools(IDX_EXTRACT_ALT_STREAMS, AltStreams, _info.AltStreams);
   GetButton_Bools(IDX_EXTRACT_NT_SECUR,    NtSecurity, _info.NtSecurity);
   GetButton_Bools(IDX_EXTRACT_ELIM_DUP,    ElimDup,    _info.ElimDup);
+  // **************** NanaZip Modification Start ****************
+  GetButton_Bools(IDX_EXTRACT_OPEN_FOLDER, OpenFolder, _info.OpenFolder);
+  // **************** NanaZip Modification End ****************
 
   bool showPassword = IsShowPasswordChecked();
   if (showPassword != _info.ShowPassword.Val)

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.h
@@ -88,6 +88,9 @@ public:
   #endif
 
   CBoolPair ElimDup;
+  // **************** NanaZip Modification Start ****************
+  CBoolPair OpenFolder;
+  // **************** NanaZip Modification End ****************
 
   INT_PTR Create(HWND aWndParent = 0)
   {

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.rc
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.rc
@@ -53,7 +53,11 @@ BEGIN
 //            g2x, m + 104, g2xs, 10
   CONTROL   "Restore file security", IDX_EXTRACT_NT_SECUR, MY_CHECKBOX,
             g2x, m + 104, g2xs, 10
-  
+  // **************** NanaZip Modification Start ****************
+  CONTROL   "&Open folder after extract", IDX_EXTRACT_OPEN_FOLDER, MY_CHECKBOX,
+            g2x, m + 118, g2xs, 10
+  // **************** NanaZip Modification End ****************
+
   DEFPUSHBUTTON  "OK",     IDOK,     bx2, by, bxs, bys, WS_GROUP
   PUSHBUTTON     "Cancel", IDCANCEL, bx1, by, bxs, bys
 END
@@ -90,7 +94,7 @@ BEGIN
   LTEXT     "Password", IDG_PASSWORD, m, m + 76, g1xs, 8
   EDITTEXT  IDE_EXTRACT_PASSWORD, m + g1xs, m + 76, xc - g1xs, 14, ES_PASSWORD | ES_AUTOHSCROLL
   CONTROL   "Show Password", IDX_PASSWORD_SHOW, MY_CHECKBOX, m, m + 92, xc, 10
-  
+
   OK_CANCEL
 END
 

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractDialogRes.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractDialogRes.h
@@ -19,6 +19,9 @@
 #define IDX_EXTRACT_ELIM_DUP        3430
 #define IDX_EXTRACT_NT_SECUR        3431
 // #define IDX_EXTRACT_ALT_STREAMS     3432
+// **************** NanaZip Modification Start ****************
+#define IDX_EXTRACT_OPEN_FOLDER     3433
+// **************** NanaZip Modification End ****************
 
 #define IDX_PASSWORD_SHOW           3803
 #define IDG_PASSWORD                3807

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractGUI.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/ExtractGUI.cpp
@@ -101,7 +101,7 @@ void CThreadExtracting::ProcessWasFinished_GuiVirt()
 HRESULT CThreadExtracting::ProcessVirt()
 {
   CDecompressStat Stat;
-  
+
   #ifndef _SFX
   /*
   if (HashBundle)
@@ -123,7 +123,7 @@ HRESULT CThreadExtracting::ProcessVirt()
         HashBundle,
       #endif
       FinalMessage.ErrorMessage.Message, Stat);
-  
+
   #ifndef _SFX
   if (res == S_OK && ExtractCallbackSpec->IsOK())
   {
@@ -136,7 +136,7 @@ HRESULT CThreadExtracting::ProcessVirt()
     else if (Options->TestMode)
     {
       UString s;
-    
+
       AddValuePair(s, IDS_ARCHIVES_COLON, Stat.NumArchives, false);
       AddSizePair(s, IDS_PROP_PACKED_SIZE, Stat.PackSize);
 
@@ -218,6 +218,9 @@ HRESULT ExtractGUI(
       dialog.PathMode = options.PathMode;
       dialog.PathMode_Force = options.PathMode_Force;
       dialog.ElimDup = options.ElimDup;
+      // **************** NanaZip Modification Start ****************
+      dialog.OpenFolder = options.OpenFolder;
+      // **************** NanaZip Modification End ****************
 
       if (archivePathsFull.Size() == 1)
         dialog.ArcPath = archivePathsFull[0];
@@ -237,7 +240,10 @@ HRESULT ExtractGUI(
       options.OverwriteMode = dialog.OverwriteMode;
       options.PathMode = dialog.PathMode;
       options.ElimDup = dialog.ElimDup;
-      
+      // **************** NanaZip Modification Start ****************
+      options.OpenFolder = dialog.OpenFolder;
+      // **************** NanaZip Modification End ****************
+
       #ifndef _SFX
       // options.NtOptions.AltStreams = dialog.AltStreams;
       options.NtOptions.NtSecurity = dialog.NtSecurity;
@@ -252,7 +258,7 @@ HRESULT ExtractGUI(
       return E_FAIL;
     }
     NName::NormalizeDirPathPrefix(options.OutputDir);
-    
+
     /*
     if (!CreateComplexDirectory(options.OutputDir))
     {
@@ -269,7 +275,7 @@ HRESULT ExtractGUI(
     }
     */
   }
-  
+
   UString title = LangString(options.TestMode ? IDS_PROGRESS_TESTING : IDS_PROGRESS_EXTRACTING);
 
   extracter.Title = title;

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/GUI.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/GUI/GUI.cpp
@@ -301,14 +301,13 @@ static int Main2()
         return NExitCode::kFatalError;
       throw CSystemException(result);
     }
+    if (!ecs->IsOK())
+      return NExitCode::kFatalError;
     // **************** NanaZip Modification Start ****************
-    else if (WantOpenFolderAfterExtract()) {
+    else if (eo.OpenFolder.Val) {
         ShellExecuteW(NULL, NULL, eo.OutputDir, NULL, NULL, SW_SHOWNORMAL);
     }
     // **************** NanaZip Modification End ****************
-    if (!ecs->IsOK())
-      return NExitCode::kFatalError;
-    
   }
   else if (options.Command.IsFromUpdateGroup())
   {

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/Extract.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/Extract.h
@@ -49,6 +49,9 @@ struct CExtractOptions: public CExtractOptionsBase
 {
   bool StdInMode;
   bool StdOutMode;
+  // **************** NanaZip Modification Start ****************
+  CBoolPair OpenFolder;
+  // **************** NanaZip Modification End ****************
   bool YesToAll;
   bool TestMode;
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
@@ -99,6 +99,9 @@ static LPCTSTR const kSplitDest = TEXT("SplitDest");
 static LPCTSTR const kElimDup = TEXT("ElimDup");
 // static LPCTSTR const kAltStreams = TEXT("AltStreams");
 static LPCTSTR const kNtSecur = TEXT("Security");
+// **************** NanaZip Modification Start ****************
+static LPCTSTR const kOpenFolderAfterExtract = TEXT("OpenFolderAfterExtract");
+// **************** NanaZip Modification End ****************
 
 void CInfo::Save() const
 {
@@ -117,6 +120,9 @@ void CInfo::Save() const
   // Key_Set_BoolPair(key, kAltStreams, AltStreams);
   Key_Set_BoolPair(key, kNtSecur, NtSecurity);
   Key_Set_BoolPair(key, kShowPassword, ShowPassword);
+  // **************** NanaZip Modification Start ****************
+  Key_Set_BoolPair(key, kOpenFolderAfterExtract, OpenFolder);
+  // **************** NanaZip Modification End ****************
 
   key.RecurseDeleteKey(kPathHistory);
   if (WantPathHistory())
@@ -168,6 +174,9 @@ void CInfo::Load()
   // Key_Get_BoolPair(key, kAltStreams, AltStreams);
   Key_Get_BoolPair(key, kNtSecur, NtSecurity);
   Key_Get_BoolPair(key, kShowPassword, ShowPassword);
+  // **************** NanaZip Modification Start ****************
+  Key_Get_BoolPair(key, kOpenFolderAfterExtract, OpenFolder);
+  // **************** NanaZip Modification End ****************
 }
 
 bool Read_ShowPassword()

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ZipRegistry.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ZipRegistry.h
@@ -34,6 +34,9 @@ namespace NExtract
     // CBoolPair AltStreams;
     CBoolPair NtSecurity;
     CBoolPair ShowPassword;
+    // **************** NanaZip Modification Start ****************
+    CBoolPair OpenFolder;
+    // **************** NanaZip Modification End ****************
 
     UStringVector Paths;
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.cpp
@@ -30,9 +30,6 @@ static LPCTSTR const kFullRow = TEXT("FullRow");
 static LPCTSTR const kShowGrid = TEXT("ShowGrid");
 static LPCTSTR const kSingleClick = TEXT("SingleClick");
 static LPCTSTR const kAlternativeSelection = TEXT("AlternativeSelection");
-// **************** NanaZip Modification Start ****************
-static LPCTSTR const kOpenFolderAfterExtract = TEXT("OpenFolderAfterExtract");
-// **************** NanaZip Modification End ****************
 // static LPCTSTR const kUnderline = TEXT("Underline");
 
 static LPCTSTR const kShowSystemMenu = TEXT("ShowSystemMenu");
@@ -155,9 +152,6 @@ void CFmSettings::Save() const
   SaveOption(kCopyHistory, CopyHistory);
   SaveOption(kFolderHistory, FolderHistory);
   SaveOption(kLowercaseHashes, LowercaseHashes);
-  // **************** NanaZip Modification Start ****************
-  SaveOption(kOpenFolderAfterExtract, OpenFolderAfterExtract);
-  // **************** NanaZip Modification End ****************
   // SaveOption(kUnderline, Underline);
 
   SaveOption(kShowSystemMenu, ShowSystemMenu);
@@ -176,7 +170,6 @@ void CFmSettings::Load()
   CopyHistory = false;
   FolderHistory = false;
   LowercaseHashes = false;
-  OpenFolderAfterExtract = false;
   // Underline = false;
 
   ShowSystemMenu = false;
@@ -195,9 +188,6 @@ void CFmSettings::Load()
     ReadOption(key, kCopyHistory, CopyHistory);
     ReadOption(key, kFolderHistory, FolderHistory);
     ReadOption(key, kLowercaseHashes, LowercaseHashes);
-    // **************** NanaZip Modification Start ****************
-    ReadOption(key, kOpenFolderAfterExtract, OpenFolderAfterExtract);
-    // **************** NanaZip Modification End ****************
     // ReadOption(key, kUnderline, Underline);
 
     ReadOption(key, kShowSystemMenu, ShowSystemMenu );
@@ -216,9 +206,6 @@ bool WantPathHistory() { return ReadFMOption(kPathHistory); }
 bool WantCopyHistory() { return ReadFMOption(kCopyHistory); }
 bool WantFolderHistory() { return ReadFMOption(kFolderHistory); }
 bool WantLowercaseHashes() { return ReadFMOption(kLowercaseHashes); }
-// **************** NanaZip Modification Start ****************
-bool WantOpenFolderAfterExtract() { return ReadFMOption(kOpenFolderAfterExtract); }
-// **************** NanaZip Modification End ****************
 
 static CSysString GetFlatViewName(UInt32 panelIndex)
 {

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/RegistryUtils.h
@@ -30,9 +30,6 @@ struct CFmSettings
   bool CopyHistory;
   bool FolderHistory;
   bool LowercaseHashes;
-  // **************** NanaZip Modification Start ****************
-  bool OpenFolderAfterExtract;
-  // **************** NanaZip Modification End ****************
   // bool Underline;
 
   bool ShowSystemMenu;
@@ -52,9 +49,6 @@ bool WantPathHistory();
 bool WantCopyHistory();
 bool WantFolderHistory();
 bool WantLowercaseHashes();
-// **************** NanaZip Modification Start ****************
-bool WantOpenFolderAfterExtract();
-// **************** NanaZip Modification End ****************
 
 void SaveFlatView(UInt32 panelIndex, bool enable);
 bool ReadFlatView(UInt32 panelIndex);

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPage.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPage.cpp
@@ -34,9 +34,6 @@ static const UInt32 kLangIDs[] =
   IDX_SETTINGS_WANT_COPY_HISTORY,
   IDX_SETTINGS_WANT_FOLDER_HISTORY,
   IDX_SETTINGS_LOWERCASE_HASHES,
-  // **************** NanaZip Modification Start ****************
-  IDX_SETTINGS_OPEN_FOLDER_AFTER
-  // **************** NanaZip Modification End ****************
   // , IDT_COMPRESS_MEMORY
 };
 
@@ -128,9 +125,6 @@ bool CSettingsPage::OnInit()
   CheckButton(IDX_SETTINGS_SHOW_GRID, st.ShowGrid);
   CheckButton(IDX_SETTINGS_SINGLE_CLICK, st.SingleClick);
   CheckButton(IDX_SETTINGS_ALTERNATIVE_SELECTION, st.AlternativeSelection);
-  // **************** NanaZip Modification Start ****************
-  CheckButton(IDX_SETTINGS_OPEN_FOLDER_AFTER, st.OpenFolderAfterExtract);
-  // **************** NanaZip Modification End ****************
   // CheckButton(IDX_SETTINGS_UNDERLINE, st.Underline);
 
   CheckButton(IDX_SETTINGS_SHOW_SYSTEM_MENU, st.ShowSystemMenu);
@@ -230,9 +224,6 @@ LONG CSettingsPage::OnApply()
     st.CopyHistory = IsButtonCheckedBool(IDX_SETTINGS_WANT_COPY_HISTORY);
     st.FolderHistory = IsButtonCheckedBool(IDX_SETTINGS_WANT_FOLDER_HISTORY);
     st.LowercaseHashes = IsButtonCheckedBool(IDX_SETTINGS_LOWERCASE_HASHES);
-    // **************** NanaZip Modification Start ****************
-    st.OpenFolderAfterExtract = IsButtonCheckedBool(IDX_SETTINGS_OPEN_FOLDER_AFTER);
-    // **************** NanaZip Modification End ****************
     // st.Underline = IsButtonCheckedBool(IDX_SETTINGS_UNDERLINE);
 
     st.ShowSystemMenu = IsButtonCheckedBool(IDX_SETTINGS_SHOW_SYSTEM_MENU);
@@ -350,9 +341,6 @@ bool CSettingsPage::OnButtonClicked(int buttonID, HWND buttonHWND)
     case IDX_SETTINGS_FULL_ROW:
     case IDX_SETTINGS_SHOW_GRID:
     case IDX_SETTINGS_ALTERNATIVE_SELECTION:
-    // **************** NanaZip Modification Start ****************
-    case IDX_SETTINGS_OPEN_FOLDER_AFTER:
-    // **************** NanaZip Modification End ****************
     case IDX_SETTINGS_WANT_ARC_HISTORY:
     case IDX_SETTINGS_WANT_PATH_HISTORY:
     case IDX_SETTINGS_WANT_COPY_HISTORY:

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPage2.rc
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPage2.rc
@@ -1,36 +1,23 @@
 // #define g1xs 60
 
 CAPTION "Settings"
-BEGIN 
+BEGIN
   CONTROL  "Show "".."" item",      IDX_SETTINGS_SHOW_DOTS,            MY_CHECKBOX, m,  8, xc, 10
   CONTROL  "Show real file &icons", IDX_SETTINGS_SHOW_REAL_FILE_ICONS, MY_CHECKBOX, m, 22, xc, 10
   CONTROL  "&Full row select",      IDX_SETTINGS_FULL_ROW,             MY_CHECKBOX, m, 36, xc, 10
   CONTROL  "Show &grid lines",      IDX_SETTINGS_SHOW_GRID,            MY_CHECKBOX, m, 50, xc, 10
   CONTROL  "&Single-click to open an item", IDX_SETTINGS_SINGLE_CLICK, MY_CHECKBOX, m, 64, xc, 10
   CONTROL  "&Alternative selection mode", IDX_SETTINGS_ALTERNATIVE_SELECTION, MY_CHECKBOX, m, 78, xc, 10
+
+  CONTROL  "Show system &menu",     IDX_SETTINGS_SHOW_SYSTEM_MENU,     MY_CHECKBOX, m, 100, xc, 10
+  CONTROL  "Use &large memory pages", IDX_SETTINGS_LARGE_PAGES,        MY_CHECKBOX, m, 122, xc, 10
+
   // **************** NanaZip Modification Start ****************
-	
-  // CONTROL  "Show system &menu",     IDX_SETTINGS_SHOW_SYSTEM_MENU,     MY_CHECKBOX, m, 100, xc, 10
-  // CONTROL  "Use &large memory pages", IDX_SETTINGS_LARGE_PAGES,        MY_CHECKBOX, m, 122, xc, 10
-
-  // CONTROL  "Want ArcHistory",    IDX_SETTINGS_WANT_ARC_HISTORY,       MY_CHECKBOX, m, 140, xc, 10
-  // CONTROL  "Want PathHistory",   IDX_SETTINGS_WANT_PATH_HISTORY,      MY_CHECKBOX, m, 154, xc, 10
-  // CONTROL  "Want CopyHistory",   IDX_SETTINGS_WANT_COPY_HISTORY,      MY_CHECKBOX, m, 168, xc, 10
-  // CONTROL  "Want FolderHistory", IDX_SETTINGS_WANT_FOLDER_HISTORY,    MY_CHECKBOX, m, 182, xc, 10
-  // CONTROL  "Use Lowercase Hashes", IDX_SETTINGS_LOWERCASE_HASHES,     MY_CHECKBOX, m, 196, xc, 10
-	
-  
-  CONTROL  "&Open folder after extract", IDX_SETTINGS_OPEN_FOLDER_AFTER, MY_CHECKBOX, m, 92, xc, 10
-
-  CONTROL  "Show system &menu",     IDX_SETTINGS_SHOW_SYSTEM_MENU,     MY_CHECKBOX, m, 114, xc, 10
-
-  CONTROL  "Use &large memory pages", IDX_SETTINGS_LARGE_PAGES,        MY_CHECKBOX, m, 136, xc, 10
-
-  CONTROL  "Want ArcHistory",    IDX_SETTINGS_WANT_ARC_HISTORY,       MY_CHECKBOX, m, 154, xc, 10
-  CONTROL  "Want PathHistory",   IDX_SETTINGS_WANT_PATH_HISTORY,      MY_CHECKBOX, m, 168, xc, 10
-  CONTROL  "Want CopyHistory",   IDX_SETTINGS_WANT_COPY_HISTORY,      MY_CHECKBOX, m, 182, xc, 10
-  CONTROL  "Want FolderHistory", IDX_SETTINGS_WANT_FOLDER_HISTORY,    MY_CHECKBOX, m, 196, xc, 10
-  CONTROL  "Use Lowercase Hashes", IDX_SETTINGS_LOWERCASE_HASHES,     MY_CHECKBOX, m, 220, xc, 10
+  CONTROL  "Want ArcHistory",    IDX_SETTINGS_WANT_ARC_HISTORY,       MY_CHECKBOX, m, 140, xc, 10
+  CONTROL  "Want PathHistory",   IDX_SETTINGS_WANT_PATH_HISTORY,      MY_CHECKBOX, m, 154, xc, 10
+  CONTROL  "Want CopyHistory",   IDX_SETTINGS_WANT_COPY_HISTORY,      MY_CHECKBOX, m, 168, xc, 10
+  CONTROL  "Want FolderHistory", IDX_SETTINGS_WANT_FOLDER_HISTORY,    MY_CHECKBOX, m, 182, xc, 10
+  CONTROL  "Use Lowercase Hashes", IDX_SETTINGS_LOWERCASE_HASHES,     MY_CHECKBOX, m, 196, xc, 10
   // **************** NanaZip Modification End ****************
 
   // LTEXT     "Memory usage for Compressing:", IDT_COMPRESS_MEMORY, m, 140, xc, 8

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPageRes.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/SettingsPageRes.h
@@ -14,9 +14,6 @@
 #define IDX_SETTINGS_WANT_COPY_HISTORY      2511
 #define IDX_SETTINGS_WANT_FOLDER_HISTORY    2512
 #define IDX_SETTINGS_LOWERCASE_HASHES       2513
-// **************** NanaZip Modification Start ****************
-#define IDX_SETTINGS_OPEN_FOLDER_AFTER       2514 
-// **************** NanaZip Modification End ****************
 
 
 // #define IDT_SETTINGS_MEM     100

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.cpp
@@ -75,6 +75,9 @@ static const UInt32 kLangIDs[] =
   // IDX_EXTRACT_ALT_STREAMS,
   IDX_EXTRACT_NT_SECUR,
   IDX_EXTRACT_ELIM_DUP,
+  // **************** NanaZip Modification Start ****************
+  IDX_EXTRACT_OPEN_FOLDER,
+  // **************** NanaZip Modification End ****************
   IDG_PASSWORD,
   IDX_PASSWORD_SHOW
 };
@@ -176,6 +179,9 @@ bool CExtractDialog::OnInit()
   // CheckButton_TwoBools(IDX_EXTRACT_ALT_STREAMS, AltStreams, _info.AltStreams);
   CheckButton_TwoBools(IDX_EXTRACT_NT_SECUR,    NtSecurity, _info.NtSecurity);
   CheckButton_TwoBools(IDX_EXTRACT_ELIM_DUP,    ElimDup,    _info.ElimDup);
+  // **************** NanaZip Modification Start ****************
+  CheckButton_TwoBools(IDX_EXTRACT_OPEN_FOLDER, OpenFolder, _info.OpenFolder);
+  // **************** NanaZip Modification End ****************
 
   CheckButton(IDX_PASSWORD_SHOW, _info.ShowPassword.Val);
   UpdatePasswordControl();
@@ -325,6 +331,9 @@ void CExtractDialog::OnOK()
   // GetButton_Bools(IDX_EXTRACT_ALT_STREAMS, AltStreams, _info.AltStreams);
   GetButton_Bools(IDX_EXTRACT_NT_SECUR,    NtSecurity, _info.NtSecurity);
   GetButton_Bools(IDX_EXTRACT_ELIM_DUP,    ElimDup,    _info.ElimDup);
+  // **************** NanaZip Modification Start ****************
+  GetButton_Bools(IDX_EXTRACT_OPEN_FOLDER, OpenFolder, _info.OpenFolder);
+  // **************** NanaZip Modification End ****************
 
   bool showPassword = IsShowPasswordChecked();
   if (showPassword != _info.ShowPassword.Val)

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.h
@@ -88,6 +88,9 @@ public:
   #endif
 
   CBoolPair ElimDup;
+  // **************** NanaZip Modification Start ****************
+  CBoolPair OpenFolder;
+  // **************** NanaZip Modification End ****************
 
   INT_PTR Create(HWND aWndParent = 0)
   {

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.rc
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractDialog.rc
@@ -53,7 +53,11 @@ BEGIN
 //            g2x, m + 104, g2xs, 10
   CONTROL   "Restore file security", IDX_EXTRACT_NT_SECUR, MY_CHECKBOX,
             g2x, m + 104, g2xs, 10
-  
+  // **************** NanaZip Modification Start ****************
+  CONTROL   "&Open folder after extract", IDX_EXTRACT_OPEN_FOLDER, MY_CHECKBOX,
+            g2x, m + 118, g2xs, 10
+  // **************** NanaZip Modification End ****************
+
   DEFPUSHBUTTON  "OK",     IDOK,     bx2, by, bxs, bys, WS_GROUP
   PUSHBUTTON     "Cancel", IDCANCEL, bx1, by, bxs, bys
 END
@@ -90,7 +94,7 @@ BEGIN
   LTEXT     "Password", IDG_PASSWORD, m, m + 76, g1xs, 8
   EDITTEXT  IDE_EXTRACT_PASSWORD, m + g1xs, m + 76, xc - g1xs, 14, ES_PASSWORD | ES_AUTOHSCROLL
   CONTROL   "Show Password", IDX_PASSWORD_SHOW, MY_CHECKBOX, m, m + 92, xc, 10
-  
+
   OK_CANCEL
 END
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractDialogRes.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractDialogRes.h
@@ -19,6 +19,9 @@
 #define IDX_EXTRACT_ELIM_DUP        3430
 #define IDX_EXTRACT_NT_SECUR        3431
 // #define IDX_EXTRACT_ALT_STREAMS     3432
+// **************** NanaZip Modification Start ****************
+#define IDX_EXTRACT_OPEN_FOLDER     3433
+// **************** NanaZip Modification End ****************
 
 #define IDX_PASSWORD_SHOW           3803
 #define IDG_PASSWORD                3807

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractGUI.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/ExtractGUI.cpp
@@ -101,7 +101,7 @@ void CThreadExtracting::ProcessWasFinished_GuiVirt()
 HRESULT CThreadExtracting::ProcessVirt()
 {
   CDecompressStat Stat;
-  
+
   #ifndef _SFX
   /*
   if (HashBundle)
@@ -123,7 +123,7 @@ HRESULT CThreadExtracting::ProcessVirt()
         HashBundle,
       #endif
       FinalMessage.ErrorMessage.Message, Stat);
-  
+
   #ifndef _SFX
   if (res == S_OK && ExtractCallbackSpec->IsOK())
   {
@@ -136,7 +136,7 @@ HRESULT CThreadExtracting::ProcessVirt()
     else if (Options->TestMode)
     {
       UString s;
-    
+
       AddValuePair(s, IDS_ARCHIVES_COLON, Stat.NumArchives, false);
       AddSizePair(s, IDS_PROP_PACKED_SIZE, Stat.PackSize);
 
@@ -218,6 +218,9 @@ HRESULT ExtractGUI(
       dialog.PathMode = options.PathMode;
       dialog.PathMode_Force = options.PathMode_Force;
       dialog.ElimDup = options.ElimDup;
+      // **************** NanaZip Modification Start ****************
+      dialog.OpenFolder = options.OpenFolder;
+      // **************** NanaZip Modification End ****************
 
       if (archivePathsFull.Size() == 1)
         dialog.ArcPath = archivePathsFull[0];
@@ -237,7 +240,10 @@ HRESULT ExtractGUI(
       options.OverwriteMode = dialog.OverwriteMode;
       options.PathMode = dialog.PathMode;
       options.ElimDup = dialog.ElimDup;
-      
+      // **************** NanaZip Modification Start ****************
+      options.OpenFolder = dialog.OpenFolder;
+      // **************** NanaZip Modification End ****************
+
       #ifndef _SFX
       // options.NtOptions.AltStreams = dialog.AltStreams;
       options.NtOptions.NtSecurity = dialog.NtSecurity;
@@ -252,7 +258,7 @@ HRESULT ExtractGUI(
       return E_FAIL;
     }
     NName::NormalizeDirPathPrefix(options.OutputDir);
-    
+
     /*
     if (!CreateComplexDirectory(options.OutputDir))
     {
@@ -269,7 +275,7 @@ HRESULT ExtractGUI(
     }
     */
   }
-  
+
   UString title = LangString(options.TestMode ? IDS_PROGRESS_TESTING : IDS_PROGRESS_EXTRACTING);
 
   extracter.Title = title;

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/GUI.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/GUI/GUI.cpp
@@ -301,15 +301,13 @@ static int Main2()
         return NExitCode::kFatalError;
       throw CSystemException(result);
     }
+    if (!ecs->IsOK())
+      return NExitCode::kFatalError;
     // **************** NanaZip Modification Start ****************
-
-    else if (WantOpenFolderAfterExtract()) {
+    else if (eo.OpenFolder.Val) {
         ShellExecuteW(NULL, NULL, eo.OutputDir, NULL, NULL, SW_SHOWNORMAL);
     }
     // **************** NanaZip Modification End ****************
-
-    if (!ecs->IsOK())
-      return NExitCode::kFatalError;
   }
   else if (options.Command.IsFromUpdateGroup())
   {

--- a/NanaZipPackage/Strings/el/Legacy.resw
+++ b/NanaZipPackage/Strings/el/Legacy.resw
@@ -657,7 +657,7 @@
   <data name="Resource2513" xml:space="preserve">
     <value>Χρήση Καταρ/σμου Πεζών Χαρακτήρων</value>
   </data>
-  <data name="Resource2514" xml:space="preserve">
+  <data name="Resource3433" xml:space="preserve">
     <value>Άνοιγμα φακέλου μετά την εξαγωγή</value>
   </data>
   <data name="Resource2900" xml:space="preserve">

--- a/NanaZipPackage/Strings/en/Legacy.resw
+++ b/NanaZipPackage/Strings/en/Legacy.resw
@@ -657,7 +657,7 @@
   <data name="Resource2513" xml:space="preserve">
     <value>Use Lowercase Hashes</value>
   </data>
-  <data name="Resource2514" xml:space="preserve">
+  <data name="Resource3433" xml:space="preserve">
     <value>Open folder after extracting</value>
   </data>
   <data name="Resource2900" xml:space="preserve">

--- a/NanaZipPackage/Strings/hu/Legacy.resw
+++ b/NanaZipPackage/Strings/hu/Legacy.resw
@@ -596,7 +596,7 @@
   </data>
   <data name="Resource2331" xml:space="preserve">
     <value>Kibontás ide ( intelligens)</value>
-  </data>  
+  </data>
   <data name="Resource2400" xml:space="preserve">
     <value>Mappák</value>
   </data>
@@ -660,7 +660,7 @@
   <data name="Resource2513" xml:space="preserve">
     <value>Használjon kisbetűs kivonatot</value>
   </data>
-  <data name="Resource2514" xml:space="preserve">
+  <data name="Resource3433" xml:space="preserve">
     <value>Mappa megnyitása a kibontás után</value>
   </data>
   <data name="Resource2900" xml:space="preserve">

--- a/NanaZipPackage/Strings/nl/Legacy.resw
+++ b/NanaZipPackage/Strings/nl/Legacy.resw
@@ -639,7 +639,7 @@
   <data name="Resource2508" xml:space="preserve">
     <value>&amp;Gebruik grote geheugenpagina's</value>
   </data>
-  <data name="Resource2514" xml:space="preserve">
+  <data name="Resource3433" xml:space="preserve">
     <value>Map openen na uitpakken</value>
   </data>
   <data name="Resource2900" xml:space="preserve">

--- a/NanaZipPackage/Strings/pl/Legacy.resw
+++ b/NanaZipPackage/Strings/pl/Legacy.resw
@@ -656,8 +656,8 @@
   </data>
   <data name="Resource2513" xml:space="preserve">
     <value>Małoliterowe sumy kontrolne</value>
-  </data> 
-  <data name="Resource2514" xml:space="preserve">
+  </data>
+  <data name="Resource3433" xml:space="preserve">
     <value>Otwórz folder po wypakowaniu</value>
   </data>
   <data name="Resource2900" xml:space="preserve">

--- a/NanaZipPackage/Strings/pt-br/Legacy.resw
+++ b/NanaZipPackage/Strings/pt-br/Legacy.resw
@@ -657,7 +657,7 @@
   <data name="Resource2513" xml:space="preserve">
     <value>Use Hashes Minúsculos</value>
   </data>
-  <data name="Resource2514" xml:space="preserve">
+  <data name="Resource3433" xml:space="preserve">
     <value>Abrir pasta após extrair</value>
   </data>
   <data name="Resource2900" xml:space="preserve">

--- a/NanaZipPackage/Strings/ru/Legacy.resw
+++ b/NanaZipPackage/Strings/ru/Legacy.resw
@@ -657,7 +657,7 @@
   <data name="Resource2513" xml:space="preserve">
     <value>Контрольные суммы строчными символами</value>
   </data>
-  <data name="Resource2514" xml:space="preserve">
+  <data name="Resource3433" xml:space="preserve">
     <value>Открыть папку после распаковки</value>
   </data>
   <data name="Resource2900" xml:space="preserve">

--- a/NanaZipPackage/Strings/sq/Legacy.resw
+++ b/NanaZipPackage/Strings/sq/Legacy.resw
@@ -657,7 +657,7 @@
   <data name="Resource2513" xml:space="preserve">
     <value>Përdor hash-et me shkronja të vogla</value>
   </data>
-  <data name="Resource2514" xml:space="preserve">
+  <data name="Resource3433" xml:space="preserve">
     <value>Hap dosjen pas shpaketimit</value>
   </data>
   <data name="Resource2900" xml:space="preserve">

--- a/NanaZipPackage/Strings/uk/Legacy.resw
+++ b/NanaZipPackage/Strings/uk/Legacy.resw
@@ -657,7 +657,7 @@
   <data name="Resource2513" xml:space="preserve">
     <value>Контрольні суми малими символами</value>
   </data>
-  <data name="Resource2514" xml:space="preserve">
+  <data name="Resource3433" xml:space="preserve">
     <value>Відкрити каталог після видобування</value>
   </data>
   <data name="Resource2900" xml:space="preserve">

--- a/NanaZipPackage/Strings/zh-Hans/Legacy.resw
+++ b/NanaZipPackage/Strings/zh-Hans/Legacy.resw
@@ -660,7 +660,7 @@
   <data name="Resource2513" xml:space="preserve">
     <value>使用小写校验值</value>
   </data>
-  <data name="Resource2514" xml:space="preserve">
+  <data name="Resource3433" xml:space="preserve">
     <value>解压后打开目标文件夹</value>
   </data>
   <data name="Resource2900" xml:space="preserve">

--- a/NanaZipPackage/Strings/zh-Hant/Legacy.resw
+++ b/NanaZipPackage/Strings/zh-Hant/Legacy.resw
@@ -660,7 +660,7 @@
   <data name="Resource2513" xml:space="preserve">
     <value>使用小寫字母驗證值</value>
   </data>
-  <data name="Resource2514" xml:space="preserve">
+  <data name="Resource3433" xml:space="preserve">
     <value>解壓縮後開啟目標資料夾</value>
   </data>
   <data name="Resource2900" xml:space="preserve">


### PR DESCRIPTION
fix #44, fix #480, fix #627

The "open folder after extraction" checkbox really should live in the extract dialog instead of as a FM setting as it is right now.