### PR TITLE
MOTW enforcement changes

### DIFF
--- a/Documents/Policies.md
+++ b/Documents/Policies.md
@@ -1,0 +1,20 @@
+# NanaZip Policies
+
+NanaZip supports setting system-wide policies via creating Registry values in
+the key `HKLM\Software\NanaZip\Policies`.
+These policies override user settings.
+
+Following is the list of currently-supported policy options.
+
+## Supported policy values
+
+### Propagate Zone.Id stream
+
+This value controls Mark-of-the-Web (MOTW) propagation of archive files.
+
+- Name: `WriteZoneIdExtract`
+- Type: REG_DWORD
+- Value:
+    - `0`: No
+    - `1`: Yes (all files)
+    - `2`: Only for unsafe extensions (does not support all nested archives)

--- a/NanaZip.Core/SevenZip/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
@@ -107,6 +107,12 @@ static const char * const kOfficeExtensions =
   " xlsx xlsm xltx xltm xlsb xla xlam"
   " ppt pot pps ppa ppam"
   " pptx pptm potx potm ppam ppsx ppsm sldx sldm"
+  // **************** NanaZip Modification Start ****************
+  // Executable types
+  " bat cmd com exe hta js jse lnk msi pif ps1 scr vbe vbs wsf"
+  // Nested archives (subset). Note: only kAll fully works on nested archives!
+  " 7z iso rar tar vhd vhdx zip"
+  // **************** NanaZip Modification End ****************
   " ";
 
 static bool FindExt2(const char *p, const UString &name)

--- a/NanaZip.Core/SevenZip/CPP/7zip/UI/Common/Extract.h
+++ b/NanaZip.Core/SevenZip/CPP/7zip/UI/Common/Extract.h
@@ -31,7 +31,7 @@ struct CExtractOptionsBase
   NExtract::NZoneIdMode::EEnum ZoneMode;
 
   CExtractNtOptions NtOptions;
-  
+
   FString OutputDir;
   UString HashDir;
 
@@ -42,7 +42,7 @@ struct CExtractOptionsBase
       OverwriteMode_Force(false),
       PathMode(NExtract::NPathMode::kFullPaths),
       OverwriteMode(NExtract::NOverwriteMode::kAsk),
-      ZoneMode(NExtract::NZoneIdMode::kNone)
+      ZoneMode(NExtract::NZoneIdMode::Default)  // NanaZip Modification
       {}
 };
 
@@ -52,7 +52,7 @@ struct CExtractOptions: public CExtractOptionsBase
   bool StdOutMode;
   bool YesToAll;
   bool TestMode;
-  
+
   // bool ShowDialog;
   // bool PasswordEnabled;
   // UString Password;

--- a/NanaZip.Core/SevenZip/CPP/7zip/UI/Common/ExtractMode.h
+++ b/NanaZip.Core/SevenZip/CPP/7zip/UI/Common/ExtractMode.h
@@ -37,6 +37,10 @@ namespace NZoneIdMode
     kAll,
     kOffice
   };
+
+  // **************** NanaZip Modification Start ****************
+  static inline const EEnum Default = kAll;
+  // **************** NanaZip Modification End ****************
 }
 
 }

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Agent/Agent.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Agent/Agent.cpp
@@ -1796,7 +1796,7 @@ STDMETHODIMP CAgent::Extract(
       false, // multiArchives
       pathMode,
       overwriteMode,
-      NExtract::NZoneIdMode::kNone,
+      NExtract::NZoneIdMode::Default,  // NanaZip Modification
       k_keepEmptyDirPrefixes);
 
   CExtractNtOptions extractNtOptions;

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Agent/Agent.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Agent/Agent.h
@@ -123,7 +123,7 @@ public:
       _isAltStreamFolder(false),
       _flatMode(false),
       _loadAltStreams(false) // _loadAltStreams alt streams works in flat mode, but we don't use it now
-      , _zoneMode(NExtract::NZoneIdMode::kNone)
+      , _zoneMode(NExtract::NZoneIdMode::Default)  // NanaZip Modification
       /* , _replaceAltStreamCharsMode(0) */
       {}
 

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
@@ -105,6 +105,12 @@ static const char * const kOfficeExtensions =
   " xlsx xlsm xltx xltm xlsb xla xlam"
   " ppt pot pps ppa ppam"
   " pptx pptm potx potm ppam ppsx ppsm sldx sldm"
+  // **************** NanaZip Modification Start ****************
+  // Executable types
+  " bat cmd com exe hta js jse lnk msi pif ps1 scr vbe vbs wsf"
+  // Nested archives (subset). Note: only kAll fully works on nested archives!
+  " 7z iso rar tar vhd vhdx zip"
+  // **************** NanaZip Modification End ****************
   " ";
 
 static bool FindExt2(const char *p, const UString &name)

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/Extract.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/Extract.h
@@ -41,7 +41,7 @@ struct CExtractOptionsBase
       OverwriteMode_Force(false),
       PathMode(NExtract::NPathMode::kFullPaths),
       OverwriteMode(NExtract::NOverwriteMode::kAsk),
-      ZoneMode(NExtract::NZoneIdMode::kNone)
+      ZoneMode(NExtract::NZoneIdMode::Default)  // NanaZip Modification
       {}
 };
 

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ExtractMode.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ExtractMode.h
@@ -37,6 +37,10 @@ namespace NZoneIdMode
     kAll,
     kOffice
   };
+
+  // **************** NanaZip Modification Start ****************
+  static inline const EEnum Default = kAll;
+  // **************** NanaZip Modification End ****************
 }
 
 }

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
@@ -25,6 +25,13 @@ static LPCTSTR const kCuPrefix = TEXT("Software") TEXT(STRING_PATH_SEPARATOR) TE
 
 static CSysString GetKeyPath(LPCTSTR path) { return kCuPrefix + (CSysString)path; }
 
+// **************** NanaZip Modification Start ****************
+static LONG OpenMachineKey(CKey &key, LPCTSTR keyName)
+{
+  return key.Open(HKEY_LOCAL_MACHINE, GetKeyPath(keyName), KEY_READ);
+}
+// **************** NanaZip Modification End ****************
+
 static LONG OpenMainKey(CKey &key, LPCTSTR keyName)
 {
   return key.Open(HKEY_CURRENT_USER, GetKeyPath(keyName), KEY_READ);
@@ -486,6 +493,9 @@ bool MemLimit_Load(NCompression::CMemUse &mu)
 }
 
 static LPCTSTR const kOptionsInfoKeyName = TEXT("Options");
+// **************** NanaZip Modification Start ****************
+static LPCTSTR const kPoliciesInfoKeyName = TEXT("Policies");
+// **************** NanaZip Modification End ****************
 
 namespace NWorkDir
 {
@@ -577,6 +587,13 @@ void CContextMenuInfo::Load()
 
   CS_LOCK
 
+  // **************** NanaZip Modification Start ****************
+  CKey policiesKey;
+  OpenMachineKey(policiesKey, kPoliciesInfoKeyName);
+
+  Key_Get_UInt32(policiesKey, kWriteZoneId, WriteZone);
+  // **************** NanaZip Modification End ****************
+
   CKey key;
   if (OpenMainKey(key, kOptionsInfoKeyName) != ERROR_SUCCESS)
     return;
@@ -585,7 +602,10 @@ void CContextMenuInfo::Load()
   Key_Get_BoolPair_true(key, kElimDup, ElimDup);
   Key_Get_BoolPair(key, kMenuIcons, MenuIcons);
 
-  Key_Get_UInt32(key, kWriteZoneId, WriteZone);
+  // **************** NanaZip Modification Start ****************
+  if (WriteZone == (UInt32)(Int32)-1)
+    Key_Get_UInt32(key, kWriteZoneId, WriteZone);
+  // **************** NanaZip Modification End ****************
 
   Flags_Def = (key.GetValue_IfOk(kContextMenu, Flags) == ERROR_SUCCESS);
 }

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
@@ -117,7 +117,7 @@ bool CMenuPage::OnInit()
   {
     unsigned wz = ci.WriteZone;
     if (wz == (UInt32)(Int32)-1)
-      wz = 0;
+      wz = NExtract::NZoneIdMode::Default; // NanaZip Modification
     for (unsigned i = 0; i <= 3; i++)
     {
       unsigned val = i;
@@ -141,7 +141,7 @@ bool CMenuPage::OnInit()
       }
       if (s.IsEmpty())
         s.Add_UInt32(val);
-      if (i == 0)
+      if (i == NExtract::NZoneIdMode::Default) // NanaZip Modification
         s.Insert(0, L"* ");
       const int index = (int)_zoneCombo.AddString(s);
       _zoneCombo.SetItemData(index, val);

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/Panel.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/Panel.h
@@ -262,7 +262,7 @@ struct CCopyToOptions
       replaceAltStreamChars(false),
       showErrorMessages(false),
       NeedRegistryZone(true),
-      ZoneIdMode(NExtract::NZoneIdMode::kNone),
+      ZoneIdMode(NExtract::NZoneIdMode::Default),  // NanaZip Modification
       VirtFileSystemSpec(NULL),
       VirtFileSystem(NULL)
       {}

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Agent/Agent.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Agent/Agent.cpp
@@ -1796,7 +1796,7 @@ STDMETHODIMP CAgent::Extract(
       false, // multiArchives
       pathMode,
       overwriteMode,
-      NExtract::NZoneIdMode::kNone,
+      NExtract::NZoneIdMode::Default,  // NanaZip Modification
       k_keepEmptyDirPrefixes);
 
   CExtractNtOptions extractNtOptions;

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Agent/Agent.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Agent/Agent.h
@@ -123,7 +123,7 @@ public:
       _isAltStreamFolder(false),
       _flatMode(false),
       _loadAltStreams(false) // _loadAltStreams alt streams works in flat mode, but we don't use it now
-      , _zoneMode(NExtract::NZoneIdMode::kNone)
+      , _zoneMode(NExtract::NZoneIdMode::Default)  // NanaZip Modification
       /* , _replaceAltStreamCharsMode(0) */
       {}
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
@@ -105,6 +105,12 @@ static const char * const kOfficeExtensions =
   " xlsx xlsm xltx xltm xlsb xla xlam"
   " ppt pot pps ppa ppam"
   " pptx pptm potx potm ppam ppsx ppsm sldx sldm"
+  // **************** NanaZip Modification Start ****************
+  // Executable types
+  " bat cmd com exe hta js jse lnk msi pif ps1 scr vbe vbs wsf"
+  // Nested archives (subset). Note: only kAll fully works on nested archives!
+  " 7z iso rar tar vhd vhdx zip"
+  // **************** NanaZip Modification End ****************
   " ";
 
 static bool FindExt2(const char *p, const UString &name)

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/Extract.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/Extract.h
@@ -41,7 +41,7 @@ struct CExtractOptionsBase
       OverwriteMode_Force(false),
       PathMode(NExtract::NPathMode::kFullPaths),
       OverwriteMode(NExtract::NOverwriteMode::kAsk),
-      ZoneMode(NExtract::NZoneIdMode::kNone)
+      ZoneMode(NExtract::NZoneIdMode::Default)  // NanaZip Modification
       {}
 };
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ExtractMode.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ExtractMode.h
@@ -37,6 +37,10 @@ namespace NZoneIdMode
     kAll,
     kOffice
   };
+
+  // **************** NanaZip Modification Start ****************
+static inline const EEnum Default = kAll;
+  // **************** NanaZip Modification End ****************
 }
 
 }

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
@@ -25,6 +25,13 @@ static LPCTSTR const kCuPrefix = TEXT("Software") TEXT(STRING_PATH_SEPARATOR) TE
 
 static CSysString GetKeyPath(LPCTSTR path) { return kCuPrefix + (CSysString)path; }
 
+// **************** NanaZip Modification Start ****************
+static LONG OpenMachineKey(CKey &key, LPCTSTR keyName)
+{
+  return key.Open(HKEY_LOCAL_MACHINE, GetKeyPath(keyName), KEY_READ);
+}
+// **************** NanaZip Modification End ****************
+
 static LONG OpenMainKey(CKey &key, LPCTSTR keyName)
 {
   return key.Open(HKEY_CURRENT_USER, GetKeyPath(keyName), KEY_READ);
@@ -486,6 +493,9 @@ bool MemLimit_Load(NCompression::CMemUse &mu)
 }
 
 static LPCTSTR const kOptionsInfoKeyName = TEXT("Options");
+// **************** NanaZip Modification Start ****************
+static LPCTSTR const kPoliciesInfoKeyName = TEXT("Policies");
+// **************** NanaZip Modification End ****************
 
 namespace NWorkDir
 {
@@ -577,6 +587,13 @@ void CContextMenuInfo::Load()
 
   CS_LOCK
 
+  // **************** NanaZip Modification Start ****************
+  CKey policiesKey;
+  OpenMachineKey(policiesKey, kPoliciesInfoKeyName);
+
+  Key_Get_UInt32(policiesKey, kWriteZoneId, WriteZone);
+  // **************** NanaZip Modification End ****************
+
   CKey key;
   if (OpenMainKey(key, kOptionsInfoKeyName) != ERROR_SUCCESS)
     return;
@@ -585,7 +602,10 @@ void CContextMenuInfo::Load()
   Key_Get_BoolPair_true(key, kElimDup, ElimDup);
   Key_Get_BoolPair(key, kMenuIcons, MenuIcons);
 
-  Key_Get_UInt32(key, kWriteZoneId, WriteZone);
+  // **************** NanaZip Modification Start ****************
+  if (WriteZone == (UInt32)(Int32)-1)
+    Key_Get_UInt32(key, kWriteZoneId, WriteZone);
+  // **************** NanaZip Modification End ****************
 
   Flags_Def = (key.GetValue_IfOk(kContextMenu, Flags) == ERROR_SUCCESS);
 }

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
@@ -117,7 +117,7 @@ bool CMenuPage::OnInit()
   {
     unsigned wz = ci.WriteZone;
     if (wz == (UInt32)(Int32)-1)
-      wz = 0;
+      wz = NExtract::NZoneIdMode::Default; // NanaZip Modification
     for (unsigned i = 0; i <= 3; i++)
     {
       unsigned val = i;
@@ -141,7 +141,7 @@ bool CMenuPage::OnInit()
       }
       if (s.IsEmpty())
         s.Add_UInt32(val);
-      if (i == 0)
+      if (i == NExtract::NZoneIdMode::Default) // NanaZip Modification
         s.Insert(0, L"* ");
       const int index = (int)_zoneCombo.AddString(s);
       _zoneCombo.SetItemData(index, val);

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.h
@@ -262,7 +262,7 @@ struct CCopyToOptions
       replaceAltStreamChars(false),
       showErrorMessages(false),
       NeedRegistryZone(true),
-      ZoneIdMode(NExtract::NZoneIdMode::kNone),
+      ZoneIdMode(NExtract::NZoneIdMode::Default),  // NanaZip Modification
       VirtFileSystemSpec(NULL),
       VirtFileSystem(NULL)
       {}

--- a/NanaZipPackage/Strings/en/Legacy.resw
+++ b/NanaZipPackage/Strings/en/Legacy.resw
@@ -822,7 +822,7 @@ Do you want to update it in the archive?</value>
     <value>Propagate Zone.Id stream:</value>
   </data>
   <data name="Resource3441" xml:space="preserve">
-    <value>For Office files</value>
+    <value>For unsafe files</value>
   </data>
   <data name="Resource3500" xml:space="preserve">
     <value>Confirm File Replace</value>

--- a/ReadMe.md
+++ b/ReadMe.md
@@ -51,6 +51,12 @@ Kenji Mouri
 - Provide 7-Zip execution alias for helping users to migrate to NanaZip.
 - Support the Per-Monitor DPI-Aware for all GUI components.
 - Support the i18n for GUI edition of Self Extracting Executable.
+- Modernize message boxes and folder browsers.
+- Provide the Smart Extraction feature.
+- Provide the Open folder after extraction option.
+- Policy mechanism for enforcing settings (see
+  [Policies.md](/Documents/Policies.md) for details)
+- Propagates Mark-of-the-Web to all files by default.
 - Provide additional hash algorithms.
   - MD2 (Inherit from 7-Zip ZS, but reimplemented with Windows CNG API)
   - MD4 (Inherit from 7-Zip ZS, but reimplemented with Windows CNG API)
@@ -125,6 +131,7 @@ Kenji Mouri
   - Enable disabling child process creation for NanaZip CLI and Self Extracting
     Executables. (Except installer mode of Self Extracting Executables, which
     compiled binaries is not provided in the NanaZip MSIX package.)
+- Various UI bug fixes and enhancements.
 
 [7-Zip ZS]: https://github.com/mcmilk/7-Zip-zstd
 [7-Zip NSIS]: https://github.com/myfreeer/7z-build-nsis


### PR DESCRIPTION
Fix #425.

- Set default MOTW mode (including NanaZip.Core) to Office files
- Add more unsafe file types (exe ps1 etc.) to MOTW extension list
- Add `HKLM\Software\NanaZip\Enforced` key for machine-wide enforcement of MOTW settings

- [x] Test