### PR TITLE
Add DisableMitigations policy.

### DIFF
--- a/Documents/Policies.md
+++ b/Documents/Policies.md
@@ -13,8 +13,19 @@ Following is the list of currently-supported policy options.
 This value controls Mark-of-the-Web (MOTW) propagation of archive files.
 
 - Name: `WriteZoneIdExtract`
-- Type: REG_DWORD
+- Type: `REG_DWORD`
 - Value:
     - `0`: No
     - `1`: Yes (all files)
     - `2`: Only for unsafe extensions (does not support all nested archives)
+
+### Disable mitigations
+
+This value controls which security mitigations should not be applied by NanaZip.
+
+- Name: `DisableMitigations`
+- Type: `REG_DWORD`
+- Value:
+    - `0`: Don't disable mitigations
+    - `1`: Disable all mitigations
+    - Other values are reserved.

--- a/NanaZip.Shared/DllBlock.cpp
+++ b/NanaZip.Shared/DllBlock.cpp
@@ -261,6 +261,10 @@ namespace
 
 EXTERN_C BOOL WINAPI NanaZipBlockDlls()
 {
+    if (NanaZipGetMitigationDisable() & 1) {
+        return TRUE;
+    }
+
     DetourTransactionBegin();
     DetourUpdateThread(GetCurrentThread());
 

--- a/NanaZip.Shared/DllBlock.h
+++ b/NanaZip.Shared/DllBlock.h
@@ -14,6 +14,7 @@
 
 #include <Windows.h>
 
+// Affected by NanaZipGetMitigationDisable().
 EXTERN_C BOOL WINAPI NanaZipBlockDlls();
 
 #endif // !NANAZIP_SHARED_DLLBLOCK

--- a/NanaZip.Shared/Mitigations.h
+++ b/NanaZip.Shared/Mitigations.h
@@ -14,6 +14,9 @@
 
 #include <Windows.h>
 
+EXTERN_C DWORD WINAPI NanaZipGetMitigationDisable();
+
+// All of the functions below are affected by NanaZipGetMitigationDisable().
 EXTERN_C BOOL WINAPI NanaZipEnableMitigations();
 EXTERN_C BOOL WINAPI NanaZipDisableChildProcesses();
 EXTERN_C BOOL WINAPI NanaZipSetThreadDynamicCodeOptout(BOOL optout);


### PR DESCRIPTION
Workaround for #497 and #645.

Add an escape hatch to disable runtime mitigations by setting the value `DisableMitigations` in NanaZip policies (HKLM only).

For now only 2 values 0 (don't disable) and 1 (disable all) are defined.