### PR TITLE
Fix issues in resource migrator

### DIFF
--- a/NanaZip.MigrateLegacyStringResources/Program.cs
+++ b/NanaZip.MigrateLegacyStringResources/Program.cs
@@ -20,7 +20,6 @@ internal class Program
 
     static readonly ImmutableArray<ResourceMapping> map =
         [
-            new(408, "ProgressPage", "CloseButtonText", true)
         ];
 
     static readonly ImmutableArray<IGrouping<string, ResourceMapping>> Mappings


### PR DESCRIPTION
This PR fixes the following issues with the resource migrator:
- If the tool is run multiple times, existing resources get added with the same name, causing duplicate errors.
- The tool doesn't override existing lines properly, so if the new file turns out to be shorter than the existing file, parts of the old file may still be present, causing parsing issues.