### PR TITLE
Fix ASAR header padding

### DIFF
--- a/NanaZip.Codecs/NanaZip.Codecs.Archive.ElectronAsar.cpp
+++ b/NanaZip.Codecs/NanaZip.Codecs.Archive.ElectronAsar.cpp
@@ -207,7 +207,12 @@ namespace NanaZip::Codecs::Archive
                 {
                     break;
                 }
-                this->m_GlobalOffset = BinaryHeaderSize + HeaderStringSize + 1;
+                this->m_GlobalOffset = BinaryHeaderSize + HeaderStringSize;
+
+                if (this->m_GlobalOffset % 4 != 0)
+                {
+                    this->m_GlobalOffset += 4 - this->m_GlobalOffset % 4;
+                }
 
                 std::string HeaderString(HeaderStringSize, '\0');
                 if (FAILED(this->ReadFileStream(


### PR DESCRIPTION
ASAR format uses Pickle to serialize binary data. Pickle adds padding to align to INT32 if the size of the variable is not divisible by 4. We need to take this into consideration when reading the header string.