### PR TITLE
Fix ExtractOnOpen setting handling.

### DIFF
--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
@@ -569,7 +569,7 @@ void CContextMenuInfo::Save() const
   Key_Set_UInt32(key, kWriteZoneId, WriteZone);
 
   // **************** NanaZip Modification Start ****************
-  Key_Set_UInt32(key, kExtractOnOpen, ExtractOnOpen);
+  Key_Set_BoolPair(key, kExtractOnOpen, ExtractOnOpen);
   // **************** NanaZip Modification End ****************
 
   if (Flags_Def)
@@ -588,6 +588,11 @@ void CContextMenuInfo::Load()
   ElimDup.Def = false;
 
   WriteZone = (UInt32)(Int32)-1;
+
+  // **************** NanaZip Modification Start ****************
+  ExtractOnOpen.Val = false;
+  ExtractOnOpen.Def = false;
+  // **************** NanaZip Modification End ****************
 
   Flags = (UInt32)(Int32)-1;
   Flags_Def = false;
@@ -611,9 +616,11 @@ void CContextMenuInfo::Load()
 
   // **************** NanaZip Modification Start ****************
   if (WriteZone == (UInt32)(Int32)-1)
+  {
     Key_Get_UInt32(key, kWriteZoneId, WriteZone);
+  }
 
-  Key_Get_UInt32(key, kExtractOnOpen, ExtractOnOpen);
+  Key_Get_BoolPair(key, kExtractOnOpen, ExtractOnOpen);
   // **************** NanaZip Modification End ****************
 
   Flags_Def = (key.GetValue_IfOk(kContextMenu, Flags) == ERROR_SUCCESS);

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ZipRegistry.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ZipRegistry.h
@@ -196,7 +196,7 @@ struct CContextMenuInfo
   UInt32 WriteZone;
 
   // **************** NanaZip Modification Start ****************
-  UInt32 ExtractOnOpen;
+  CBoolPair ExtractOnOpen;
   // **************** NanaZip Modification End ****************
 
   /*

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
@@ -478,18 +478,33 @@ static bool CallExtractOnOpen() {
 
   ci.Load();
 
-  if (!g_IsFileTypeHandler || !ci.ExtractOnOpen || g_MainPath.IsEmpty())
+  if (
+    !g_IsFileTypeHandler ||
+    !ci.ExtractOnOpen.Val ||
+    ::GetAsyncKeyState(VK_SHIFT) < 0)
+  {
     return false;
-  if (::GetAsyncKeyState(VK_SHIFT) < 0)
+  }
+  if (
+    g_MainPath.IsEmpty() ||
+    !NFile::NName::GetFullPath(us2fs(g_MainPath), fullPathF))
+  {
     return false;
-  if (!NWindows::NFile::NName::GetFullPath(us2fs(g_MainPath), fullPathF))
+  }
+  if (!NFile::NDir::GetOnlyDirPrefix(fullPathF, parentFolder))
+  {
     return false;
-  if (!NWindows::NFile::NDir::GetOnlyDirPrefix(fullPathF, parentFolder))
-    return false;
+  }
 
   arcPaths.Add(fs2us(fullPathF));
-  ExtractArchives(arcPaths, fs2us(parentFolder), false, false, ci.WriteZone,
-    true, true);
+  ::ExtractArchives(
+    arcPaths,
+    fs2us(parentFolder),
+    false,
+    false,
+    ci.WriteZone,
+    true,
+    true);
   return true;
 }
 // **************** NanaZip Modification End ****************

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
@@ -113,8 +113,9 @@ bool CMenuPage::OnInit()
   ci.Load();
 
   CheckButton(IDX_EXTRACT_ELIM_DUP, ci.ElimDup.Val);
+
   // **************** NanaZip Modification Start ****************
-  CheckButton(IDX_EXTRACT_ON_OPEN, ci.ExtractOnOpen);
+  CheckButton(IDX_EXTRACT_ON_OPEN, ci.ExtractOnOpen.Val);
   // **************** NanaZip Modification End ****************
 
   _listView.Attach(GetItem(IDL_SYSTEM_OPTIONS));
@@ -210,7 +211,12 @@ bool CMenuPage::OnInit()
 LONG CMenuPage::OnApply()
 {
   // **************** NanaZip Modification Start ****************
-  if (_elimDup_Changed || _writeZone_Changed || _flags_Changed || _extractOnOpen_Changed)
+  // if (_elimDup_Changed || _writeZone_Changed || _flags_Changed)
+  if (
+    _elimDup_Changed ||
+    _writeZone_Changed ||
+    _flags_Changed ||
+    m_ExtractOnOpenChanged)
   // **************** NanaZip Modification End ****************
   {
     CContextMenuInfo ci;
@@ -234,7 +240,8 @@ LONG CMenuPage::OnApply()
     ci.Flags_Def = _flags_Changed;
 
     // **************** NanaZip Modification Start ****************
-    ci.ExtractOnOpen = IsButtonCheckedBool(IDX_EXTRACT_ON_OPEN);
+    ci.ExtractOnOpen.Val = IsButtonCheckedBool(IDX_EXTRACT_ON_OPEN);
+    ci.ExtractOnOpen.Def = m_ExtractOnOpenChanged;
     // **************** NanaZip Modification End ****************
 
     ci.Save();
@@ -252,9 +259,13 @@ bool CMenuPage::OnButtonClicked(int buttonID, HWND buttonHWND)
   switch (buttonID)
   {
     case IDX_EXTRACT_ELIM_DUP: _elimDup_Changed = true; break;
+
     // **************** NanaZip Modification Start ****************
-    case IDX_EXTRACT_ON_OPEN: _extractOnOpen_Changed = true; break;
+    case IDX_EXTRACT_ON_OPEN:
+      m_ExtractOnOpenChanged = true;
+      break;
     // **************** NanaZip Modification End ****************
+
     // case IDX_EXTRACT_WRITE_ZONE: _writeZone_Changed = true; break;
 
     case IDB_SYSTEM_ASSOCIATE:

--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/MenuPage.h
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/MenuPage.h
@@ -14,8 +14,9 @@ class CMenuPage: public NWindows::NControl::CPropertyPage
   bool _elimDup_Changed;
   bool _writeZone_Changed;
   bool _flags_Changed;
+
   // **************** NanaZip Modification Start ****************
-  bool _extractOnOpen_Changed;
+  bool m_ExtractOnOpenChanged;
   // **************** NanaZip Modification End ****************
 
   void Clear_MenuChanged()
@@ -23,8 +24,9 @@ class CMenuPage: public NWindows::NControl::CPropertyPage
     _elimDup_Changed = false;
     _writeZone_Changed = false;
     _flags_Changed = false;
+
     // **************** NanaZip Modification Start ****************
-    _extractOnOpen_Changed = false;
+    m_ExtractOnOpenChanged = false;
     // **************** NanaZip Modification End ****************
   }
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ZipRegistry.cpp
@@ -569,7 +569,7 @@ void CContextMenuInfo::Save() const
   Key_Set_UInt32(key, kWriteZoneId, WriteZone);
 
   // **************** NanaZip Modification Start ****************
-  Key_Set_UInt32(key, kExtractOnOpen, ExtractOnOpen);
+  Key_Set_BoolPair(key, kExtractOnOpen, ExtractOnOpen);
   // **************** NanaZip Modification End ****************
 
   if (Flags_Def)
@@ -588,6 +588,11 @@ void CContextMenuInfo::Load()
   ElimDup.Def = false;
 
   WriteZone = (UInt32)(Int32)-1;
+
+  // **************** NanaZip Modification Start ****************
+  ExtractOnOpen.Val = false;
+  ExtractOnOpen.Def = false;
+  // **************** NanaZip Modification End ****************
 
   Flags = (UInt32)(Int32)-1;
   Flags_Def = false;
@@ -611,9 +616,11 @@ void CContextMenuInfo::Load()
 
   // **************** NanaZip Modification Start ****************
   if (WriteZone == (UInt32)(Int32)-1)
+  {
     Key_Get_UInt32(key, kWriteZoneId, WriteZone);
+  }
 
-  Key_Get_UInt32(key, kExtractOnOpen, ExtractOnOpen);
+  Key_Get_BoolPair(key, kExtractOnOpen, ExtractOnOpen);
   // **************** NanaZip Modification End ****************
 
   Flags_Def = (key.GetValue_IfOk(kContextMenu, Flags) == ERROR_SUCCESS);

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ZipRegistry.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ZipRegistry.h
@@ -196,7 +196,7 @@ struct CContextMenuInfo
   UInt32 WriteZone;
 
   // **************** NanaZip Modification Start ****************
-  UInt32 ExtractOnOpen;
+  CBoolPair ExtractOnOpen;
   // **************** NanaZip Modification End ****************
 
   /*

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
@@ -475,18 +475,33 @@ static bool CallExtractOnOpen() {
 
   ci.Load();
 
-  if (!g_IsFileTypeHandler || !ci.ExtractOnOpen || g_MainPath.IsEmpty())
+  if (
+    !g_IsFileTypeHandler ||
+    !ci.ExtractOnOpen.Val ||
+    ::GetAsyncKeyState(VK_SHIFT) < 0)
+  {
     return false;
-  if (::GetAsyncKeyState(VK_SHIFT) < 0)
+  }
+  if (
+    g_MainPath.IsEmpty() ||
+    !NFile::NName::GetFullPath(us2fs(g_MainPath), fullPathF))
+  {
     return false;
-  if (!NWindows::NFile::NName::GetFullPath(us2fs(g_MainPath), fullPathF))
+  }
+  if (!NFile::NDir::GetOnlyDirPrefix(fullPathF, parentFolder))
+  {
     return false;
-  if (!NWindows::NFile::NDir::GetOnlyDirPrefix(fullPathF, parentFolder))
-    return false;
+  }
 
   arcPaths.Add(fs2us(fullPathF));
-  ExtractArchives(arcPaths, fs2us(parentFolder), false, false, ci.WriteZone,
-    true, true);
+  ::ExtractArchives(
+    arcPaths,
+    fs2us(parentFolder),
+    false,
+    false,
+    ci.WriteZone,
+    true,
+    true);
   return true;
 }
 // **************** NanaZip Modification End ****************

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
@@ -113,8 +113,9 @@ bool CMenuPage::OnInit()
   ci.Load();
 
   CheckButton(IDX_EXTRACT_ELIM_DUP, ci.ElimDup.Val);
+
   // **************** NanaZip Modification Start ****************
-  CheckButton(IDX_EXTRACT_ON_OPEN, ci.ExtractOnOpen);
+  CheckButton(IDX_EXTRACT_ON_OPEN, ci.ExtractOnOpen.Val);
   // **************** NanaZip Modification End ****************
 
   _listView.Attach(GetItem(IDL_SYSTEM_OPTIONS));
@@ -210,7 +211,12 @@ bool CMenuPage::OnInit()
 LONG CMenuPage::OnApply()
 {
   // **************** NanaZip Modification Start ****************
-  if (_elimDup_Changed || _writeZone_Changed || _flags_Changed || _extractOnOpen_Changed)
+  // if (_elimDup_Changed || _writeZone_Changed || _flags_Changed)
+  if (
+    _elimDup_Changed ||
+    _writeZone_Changed ||
+    _flags_Changed ||
+    m_ExtractOnOpenChanged)
   // **************** NanaZip Modification End ****************
   {
     CContextMenuInfo ci;
@@ -234,7 +240,8 @@ LONG CMenuPage::OnApply()
     ci.Flags_Def = _flags_Changed;
 
     // **************** NanaZip Modification Start ****************
-    ci.ExtractOnOpen = IsButtonCheckedBool(IDX_EXTRACT_ON_OPEN);
+    ci.ExtractOnOpen.Val = IsButtonCheckedBool(IDX_EXTRACT_ON_OPEN);
+    ci.ExtractOnOpen.Def = m_ExtractOnOpenChanged;
     // **************** NanaZip Modification End ****************
 
     ci.Save();
@@ -252,9 +259,13 @@ bool CMenuPage::OnButtonClicked(int buttonID, HWND buttonHWND)
   switch (buttonID)
   {
     case IDX_EXTRACT_ELIM_DUP: _elimDup_Changed = true; break;
+
     // **************** NanaZip Modification Start ****************
-    case IDX_EXTRACT_ON_OPEN: _extractOnOpen_Changed = true; break;
+    case IDX_EXTRACT_ON_OPEN:
+      m_ExtractOnOpenChanged = true;
+      break;
     // **************** NanaZip Modification End ****************
+
     // case IDX_EXTRACT_WRITE_ZONE: _writeZone_Changed = true; break;
 
     case IDB_SYSTEM_ASSOCIATE:

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/MenuPage.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/MenuPage.h
@@ -14,8 +14,9 @@ class CMenuPage: public NWindows::NControl::CPropertyPage
   bool _elimDup_Changed;
   bool _writeZone_Changed;
   bool _flags_Changed;
+
   // **************** NanaZip Modification Start ****************
-  bool _extractOnOpen_Changed;
+  bool m_ExtractOnOpenChanged;
   // **************** NanaZip Modification End ****************
 
   void Clear_MenuChanged()
@@ -23,8 +24,9 @@ class CMenuPage: public NWindows::NControl::CPropertyPage
     _elimDup_Changed = false;
     _writeZone_Changed = false;
     _flags_Changed = false;
+
     // **************** NanaZip Modification Start ****************
-    _extractOnOpen_Changed = false;
+    m_ExtractOnOpenChanged = false;
     // **************** NanaZip Modification End ****************
   }
 


### PR DESCRIPTION
ExtractOnOpen originally used UInt32 which was incorrect. Switch to CBoolPair like it should have been.

Also rearrange and reformat the affected code to better follow the style guide.

<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Documents/Security.md.
-->
