### PR TITLE
Implement archive handler restrictions policy

### DIFF
--- a/Documents/Policies.md
+++ b/Documents/Policies.md
@@ -29,3 +29,29 @@ This value controls which security mitigations should not be applied by NanaZip.
     - `0`: Don't disable mitigations
     - `1`: Disable all mitigations
     - Other values are reserved.
+
+### Archive handler restrictions
+
+These values control which archive handlers can be loaded by NanaZip.
+
+With this policy, you can significantly limit the attack surface of NanaZip by
+blocking the parsing of unusual archive formats.
+
+If AllowedHandlers is present, only the handlers specified in said list will be
+allowed.
+
+If BlockedHandlers is present, the handlers specified in said list will be
+blocked. BlockedHandlers takes precedence over AllowedHandlers; i.e. handlers
+specified in BlockedHandlers will still be blocked even if they're specified in
+AllowedHandlers.
+
+Look for `REGISTER_ARC` in NanaZip.Core for the list of handlers bundled with
+NanaZip.
+
+- Name: `AllowedHandlers`
+- Type: `REG_MULTI_SZ`
+- Value: List of allowed archive handlers (case-sensitive).
+
+- Name: `BlockedHandlers`
+- Type: `REG_MULTI_SZ`
+- Value: List of blocked archive handlers (case-sensitive).

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/ArchiveExports.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/ArchiveExports.cpp
@@ -15,11 +15,105 @@ static unsigned g_NumArcs = 0;
 static unsigned g_DefaultArcIndex = 0;
 static const CArcInfo *g_Arcs[kNumArcsMax];
 
+// **************** NanaZip Modification Start ****************
+#ifndef Z7_SFX
+static PCZZSTR GetMultiStringA(PCSTR Name)
+{
+    PZZSTR Result = nullptr;
+    DWORD Length = 0;
+    LSTATUS Status;
+
+    ::RegGetValueA(
+        HKEY_LOCAL_MACHINE,
+        "Software\\NanaZip\\Policies",
+        Name,
+        RRF_RT_REG_MULTI_SZ,
+        nullptr,
+        nullptr,
+        &Length);
+    if (Length == 0)
+    {
+        return nullptr;
+    }
+
+    Result = static_cast<PZZSTR>(std::calloc(Length, sizeof(CHAR)));
+    if (!Result)
+    {
+        return nullptr;
+    }
+
+    Status = ::RegGetValueA(
+        HKEY_LOCAL_MACHINE,
+        "Software\\NanaZip\\Policies",
+        Name,
+        RRF_RT_REG_MULTI_SZ,
+        nullptr,
+        reinterpret_cast<PVOID>(Result),
+        &Length);
+    if (Status != ERROR_SUCCESS)
+    {
+        std::free(Result);
+        return nullptr;
+    }
+
+    return Result;
+}
+
+static bool MultiStringFindStringA(PCZZSTR Haystack, PCSTR Needle)
+{
+    PCSTR Current;
+
+    if (!Haystack || !Needle)
+    {
+        return false;
+    }
+
+    for (Current = Haystack;
+        *Current;
+        Current = Current + std::strlen(Current) + 1)
+    {
+        if (!std::strcmp(Current, Needle))
+        {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+static PCZZSTR AllowedHandlers()
+{
+    static PCZZSTR CachedResult = ::GetMultiStringA("AllowedHandlers");
+    return CachedResult;
+}
+
+static PCZZSTR BlockedHandlers()
+{
+    static PCZZSTR CachedResult = ::GetMultiStringA("BlockedHandlers");
+    return CachedResult;
+}
+#endif
+// **************** NanaZip Modification End ****************
+
 void RegisterArc(const CArcInfo *arcInfo) throw()
 {
   if (g_NumArcs < kNumArcsMax)
   {
     const char *p = arcInfo->Name;
+    // **************** NanaZip Modification Start ****************
+#ifndef Z7_SFX
+    if (AllowedHandlers() &&
+        !::MultiStringFindStringA(AllowedHandlers(), p))
+    {
+        return;
+    }
+    if (BlockedHandlers() &&
+        ::MultiStringFindStringA(BlockedHandlers(), p))
+    {
+        return;
+    }
+#endif
+    // **************** NanaZip Modification End ****************
     if (p[0] == '7' && p[1] == 'z' && p[2] == 0)
       g_DefaultArcIndex = g_NumArcs;
     g_Arcs[g_NumArcs++] = arcInfo;
@@ -72,7 +166,7 @@ STDAPI CreateArchiver(const GUID *clsid, const GUID *iid, void **outObject)
     const int formatIndex = FindFormatCalssId(clsid);
     if (formatIndex < 0)
       return CLASS_E_CLASSNOTAVAILABLE;
-    
+
     const CArcInfo &arc = *g_Arcs[formatIndex];
     if (needIn)
     {


### PR DESCRIPTION
<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Documents/Security.md.
-->

Add a policy to control which archive handlers can be loaded by NanaZip.

With this policy, you can significantly limit the attack surface of NanaZip by blocking the parsing of unusual archive formats.

If AllowedHandlers is present, only the handlers specified in said list will be allowed.

If BlockedHandlers is present, the handlers specified in said list will be blocked. BlockedHandlers takes precedence over AllowedHandlers; i.e. handlers specified in BlockedHandlers will still be blocked even if they're specified in AllowedHandlers.