### PR TITLE
Fix text overflow in German translation

### DIFF
--- a/NanaZipPackage/Strings/de/Legacy.resw
+++ b/NanaZipPackage/Strings/de/Legacy.resw
@@ -1297,6 +1297,6 @@ Sind Sie sicher, dass das Archiv dementsprechend aufgesplittet werden soll?</val
     <value>Integration</value>
   </data>
   <data name="Resource12201" xml:space="preserve">
-    <value>Windowseinstellungen/Standard-Apps öffnen, um Dateien mit NanaZip zu verknüpfen</value>
+    <value>Windows-Einstellungen öffnen, um Dateien mit NanaZip zu verknüpfen</value>
   </data>
 </root>


### PR DESCRIPTION
<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Documents/Security.md.
-->

This PR reduces the length of a single string in the german translation to fix an overflow in the UI

Before:
<img width="426" height="571" alt="Screenshot 2025-09-16 174024" src="https://github.com/user-attachments/assets/df107e23-13b1-4cab-ad82-f09887d6ed4c" />

After:
<img width="476" height="572" alt="Screenshot 2025-09-16 174003" src="https://github.com/user-attachments/assets/fb7406bb-ac19-4c2e-b2bf-3ff325d03d75" />
