### PR TITLE
Set SFX dependent load flags to only search System32

### DIFF
--- a/NanaZip.Core/NanaZip.Core.Sfx.Shared.props
+++ b/NanaZip.Core/NanaZip.Core.Sfx.Shared.props
@@ -12,6 +12,16 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>$(OutDir)NanaZip.Core.Sfx.Shared.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <!--
+        Set the dependent load flag to LOAD_LIBRARY_SEARCH_SYSTEM32 to prevent
+        static imports from searching elsewhere:
+        https://docs.microsoft.com/en-us/cpp/build/reference/dependentloadflag
+        Note that any new static imports on the SFX must be audited since this
+        flag may not cover all scenarios; see
+        https://github.com/pbatard/rufus/issues/2701#issuecomment-2874788564
+        for more details.
+      -->
+      <AdditionalOptions Condition="'$(Configuration)' == 'Release'">%(AdditionalOptions) /DEPENDENTLOADFLAG:0x800</AdditionalOptions>
     </Link>
   </ItemDefinitionGroup>
   <Target Name="NanaZipCoreSfxSharedBuildCSource" BeforeTargets="BeforeClCompile">


### PR DESCRIPTION
Unlike the 7-Zip SFX, NanaZip SFX makes use of DLL imports that don't belong to KnownDlls (e.g. bcrypt.dll and uxtheme.dll). It is therefore vulnerable to a DLL planting attack if DLL redirection could be successfully triggered.

Set the LOAD_LIBRARY_SEARCH_SYSTEM32 dependent load flag on Release builds to prevent this problem on Windows 10 build 14393 and later.

There are some caveats as described in [this comment here at pbatard/rufus](https://redirect.github.com/pbatard/rufus/issues/2701#issuecomment-2874788564), but I couldn't trigger them in the SFX build. (Is it because Rufus is trying to load these DLLs dynamically, which isn't covered by this load flag?)