### PR TITLE
Fix condition in GetExtractStream SetLink branch

### DIFF
--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
@@ -1380,8 +1380,8 @@ HRESULT CArchiveExtractCallback::GetExtractStream(CMyComPtr<ISequentialOutStream
 
   // **************** NanaZip Modification Start ****************
   // Backported from 25.00.
-  //if (_link.linkPath.IsEmpty())
-  if (_link.LinkPath.IsEmpty())
+  //if (!_link.linkPath.IsEmpty())
+  if (!_link.LinkPath.IsEmpty())
   {
     #ifndef UNDER_CE
     {

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/Common/ArchiveExtractCallback.cpp
@@ -1380,8 +1380,8 @@ HRESULT CArchiveExtractCallback::GetExtractStream(CMyComPtr<ISequentialOutStream
 
   // **************** NanaZip Modification Start ****************
   // Backported from 25.00.
-  //if (_link.linkPath.IsEmpty())
-  if (_link.LinkPath.IsEmpty())
+  //if (!_link.linkPath.IsEmpty())
+  if (!_link.LinkPath.IsEmpty())
   {
     #ifndef UNDER_CE
     {


### PR DESCRIPTION
Follow-up for #783, fix #766.

The condition was reversed by accident during the backport.

Manually verified with the PoC from https://github.com/pacbypass/CVE-2025-11001 (got a "Dangerous link path was ignored" warning, extracted file could not escape the output directory unlike NanaZip 5.0).

<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Documents/Security.md.
-->
