### PR TITLE
Localize Open Inside menu text

### DIFF
--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/MyLoadMenu.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/MyLoadMenu.cpp
@@ -168,6 +168,9 @@ static void MyChangeMenu(HMENU menuLoc, int level, int menuIndex)
 
         UInt32 langID = langPos >= 0 ? kIDLangPairs[langPos].LangID : item.wID;
 
+        // **************** NanaZip Modification Start ****************
+        // */# localization logic removed from NanaZip.
+        #if 0 // ******** Annotated 7-Zip Mainline Source Code snippet Start ********
         if (langID == IDM_OPEN_INSIDE_ONE || langID == IDM_OPEN_INSIDE_PARSER)
         {
           LangString_OnlyFromLangFile(IDM_OPEN_INSIDE, newString);
@@ -180,6 +183,9 @@ static void MyChangeMenu(HMENU menuLoc, int level, int menuIndex)
           newString += (langID == IDM_OPEN_INSIDE_ONE ? " *" : " #");
         }
         else if (langID == IDM_BENCHMARK2)
+        #endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
+        if (langID == IDM_BENCHMARK2)
+        // **************** NanaZip Modification End ****************
         {
           LangString_OnlyFromLangFile(IDM_BENCHMARK, newString);
           if (newString.IsEmpty())

--- a/NanaZipPackage/Strings/af/Legacy.resw
+++ b/NanaZipPackage/Strings/af/Legacy.resw
@@ -162,6 +162,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>A&amp;fsluit</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Open Binne *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Open Binne #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Selekteer &amp;alles</value>
   </data>

--- a/NanaZipPackage/Strings/ar/Legacy.resw
+++ b/NanaZipPackage/Strings/ar/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;الجداول البديلة</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>افتح بالداخل *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>افتح بالداخل #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>تحديد ال&amp;كل</value>
   </data>

--- a/NanaZipPackage/Strings/az-arab/Legacy.resw
+++ b/NanaZipPackage/Strings/az-arab/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Əvəzedici Axınlar</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Daxildə Açmaq *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Daxildə Açmaq #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>&amp;Hamısını Seçmək</value>
   </data>

--- a/NanaZipPackage/Strings/be/Legacy.resw
+++ b/NanaZipPackage/Strings/be/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>В&amp;ыхад</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Адкрыць усярэдзіне *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Адкрыць усярэдзіне #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Вылучыць у&amp;сё</value>
   </data>

--- a/NanaZipPackage/Strings/bg/Legacy.resw
+++ b/NanaZipPackage/Strings/bg/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Из&amp;ход</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Отваряне в *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Отваряне в #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>&amp;Маркиране на всички</value>
   </data>

--- a/NanaZipPackage/Strings/bn/Legacy.resw
+++ b/NanaZipPackage/Strings/bn/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>বাহির</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>NanaZip-এ উন্মুক্ত করা *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>NanaZip-এ উন্মুক্ত করা #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>সব নির্বাচন</value>
   </data>

--- a/NanaZipPackage/Strings/ca-es-valencia/Legacy.resw
+++ b/NanaZipPackage/Strings/ca-es-valencia/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Eixir</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Obrir dins *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Obrir dins #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Seleccion&amp;ar-ho tot</value>
   </data>

--- a/NanaZipPackage/Strings/ca/Legacy.resw
+++ b/NanaZipPackage/Strings/ca/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>S&amp;urt</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Obre dins *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Obre dins #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Enlla&amp;ç</value>
   </data>

--- a/NanaZipPackage/Strings/cs/Legacy.resw
+++ b/NanaZipPackage/Strings/cs/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Konec</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Otevřít uvnitř *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Otevřít uvnitř #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Odkázat</value>
   </data>

--- a/NanaZipPackage/Strings/cy/Legacy.resw
+++ b/NanaZipPackage/Strings/cy/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Alla&amp;n</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Agor tu Mewn *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Agor tu Mewn #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Dewis y C&amp;yfan</value>
   </data>

--- a/NanaZipPackage/Strings/da/Legacy.resw
+++ b/NanaZipPackage/Strings/da/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Afslut</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Åbn inden i *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Åbn inden i #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Opret/rediger henvisning</value>
   </data>

--- a/NanaZipPackage/Strings/de/Legacy.resw
+++ b/NanaZipPackage/Strings/de/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Be&amp;enden</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Intern öffnen *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Intern öffnen #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Verknüpfung...</value>
   </data>

--- a/NanaZipPackage/Strings/el/Legacy.resw
+++ b/NanaZipPackage/Strings/el/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Έ&amp;ξοδος</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Άνοιγμα στο ίδιο παράθυρο *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Άνοιγμα στο ίδιο παράθυρο #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Σύνδεσμος</value>
   </data>

--- a/NanaZipPackage/Strings/en/Legacy.resw
+++ b/NanaZipPackage/Strings/en/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Alternate Streams</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Open Inside (One level)</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Open Inside (Parser)</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Select &amp;All</value>
   </data>

--- a/NanaZipPackage/Strings/eo/Legacy.resw
+++ b/NanaZipPackage/Strings/eo/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>E&amp;liru</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Malfermu ene *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Malfermu ene #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>M&amp;arku ĉiun</value>
   </data>

--- a/NanaZipPackage/Strings/es/Legacy.resw
+++ b/NanaZipPackage/Strings/es/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Salir</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Abrir dentro *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Abrir dentro #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Vincular</value>
   </data>

--- a/NanaZipPackage/Strings/et/Legacy.resw
+++ b/NanaZipPackage/Strings/et/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Välju</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Ava sees *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Ava sees #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>V&amp;ali kõik</value>
   </data>

--- a/NanaZipPackage/Strings/eu/Legacy.resw
+++ b/NanaZipPackage/Strings/eu/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>I&amp;rten</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Ireki Barnean *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Ireki Barnean #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Lotura</value>
   </data>

--- a/NanaZipPackage/Strings/fa/Legacy.resw
+++ b/NanaZipPackage/Strings/fa/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;جریان‌های جایگزین</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>بازکردن از داخل *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>بازکردن از داخل #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>انتخاب همه</value>
   </data>

--- a/NanaZipPackage/Strings/fi/Legacy.resw
+++ b/NanaZipPackage/Strings/fi/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Lopeta</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Avaa sisäisesti *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Avaa sisäisesti #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Linkitä</value>
   </data>

--- a/NanaZipPackage/Strings/fr/Legacy.resw
+++ b/NanaZipPackage/Strings/fr/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Quitter</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Ouvrir à l'intérieur *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Ouvrir à l'intérieur #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Lien</value>
   </data>

--- a/NanaZipPackage/Strings/fy/Legacy.resw
+++ b/NanaZipPackage/Strings/fy/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>U&amp;tgong</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Iepenje yn *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Iepenje yn #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>&amp;Alles selektearje</value>
   </data>

--- a/NanaZipPackage/Strings/ga/Legacy.resw
+++ b/NanaZipPackage/Strings/ga/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Scoir</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Oscail istigh *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Oscail istigh #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Roghnaigh &amp;uile</value>
   </data>

--- a/NanaZipPackage/Strings/gl/Legacy.resw
+++ b/NanaZipPackage/Strings/gl/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Sa&amp;ír</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Abrir dentro *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Abrir dentro #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Ligazón</value>
   </data>

--- a/NanaZipPackage/Strings/gu/Legacy.resw
+++ b/NanaZipPackage/Strings/gu/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;નિર્ગમન</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>અંદર ખોલો *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>અંદર ખોલો #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>&amp;બધા ચયન કરો</value>
   </data>

--- a/NanaZipPackage/Strings/he/Legacy.resw
+++ b/NanaZipPackage/Strings/he/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;צא</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>פתח בפנים *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>פתח בפנים #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>קַשֵׁר</value>
   </data>

--- a/NanaZipPackage/Strings/hi/Legacy.resw
+++ b/NanaZipPackage/Strings/hi/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;निर्गमन</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>अंदर खोले *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>अंदर खोले #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>&amp;सभी चयन करे</value>
   </data>

--- a/NanaZipPackage/Strings/hr/Legacy.resw
+++ b/NanaZipPackage/Strings/hr/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Izlaz</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Otvori mapu *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Otvori mapu #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Poveznica</value>
   </data>

--- a/NanaZipPackage/Strings/hu/Legacy.resw
+++ b/NanaZipPackage/Strings/hu/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Kilépés</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Megnyitás belül *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Megnyitás belül #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Hivatkozás</value>
   </data>

--- a/NanaZipPackage/Strings/hy/Legacy.resw
+++ b/NanaZipPackage/Strings/hy/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Փակ&amp;ել</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Բացել ներսում *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Բացել ներսում #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Հղում</value>
   </data>

--- a/NanaZipPackage/Strings/id/Legacy.resw
+++ b/NanaZipPackage/Strings/id/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Keluar</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Buka di Dalam *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Buka di Dalam #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Tautan</value>
   </data>

--- a/NanaZipPackage/Strings/is/Legacy.resw
+++ b/NanaZipPackage/Strings/is/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Hætta</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Opna að innanverðu *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Opna að innanverðu #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Tengill</value>
   </data>

--- a/NanaZipPackage/Strings/it/Legacy.resw
+++ b/NanaZipPackage/Strings/it/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>E&amp;sci</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Apri in NanaZip File Manager *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Apri in NanaZip File Manager #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Collegamento</value>
   </data>

--- a/NanaZipPackage/Strings/ja/Legacy.resw
+++ b/NanaZipPackage/Strings/ja/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>閉じる(&amp;X)</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>NanaZip で開く *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>NanaZip で開く #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>リンク</value>
   </data>

--- a/NanaZipPackage/Strings/ka/Legacy.resw
+++ b/NanaZipPackage/Strings/ka/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>გ&amp;ამოსვლა</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>გახსნა შიგნით *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>გახსნა შიგნით #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>&amp;ყველაფრის მონიშვნა</value>
   </data>

--- a/NanaZipPackage/Strings/kk/Legacy.resw
+++ b/NanaZipPackage/Strings/kk/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Шығу</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Ішінен ашу *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Ішінен ашу #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Бәрін ерекшелеу</value>
   </data>

--- a/NanaZipPackage/Strings/ko/Legacy.resw
+++ b/NanaZipPackage/Strings/ko/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>끝내기(&amp;X)</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>내부 열기 *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>내부 열기 #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>연결</value>
   </data>

--- a/NanaZipPackage/Strings/ku-arab/Legacy.resw
+++ b/NanaZipPackage/Strings/ku-arab/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>دەر&amp;چوون</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>کردنەوە لەناو خۆدا *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>کردنەوە لەناو خۆدا #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>هەمووی دیاری بکە</value>
   </data>

--- a/NanaZipPackage/Strings/ky-kg/Legacy.resw
+++ b/NanaZipPackage/Strings/ky-kg/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Ч&amp;ыгуу</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Ичинен ачуу *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Ичинен ачуу #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Баарын б&amp;өлүү</value>
   </data>

--- a/NanaZipPackage/Strings/lt/Legacy.resw
+++ b/NanaZipPackage/Strings/lt/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Išei&amp;ti</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Atverti viduje *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Atverti viduje #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Nuoroda</value>
   </data>

--- a/NanaZipPackage/Strings/lv/Legacy.resw
+++ b/NanaZipPackage/Strings/lv/Legacy.resw
@@ -162,6 +162,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Beigt</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Atvērt iekšpusē *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Atvērt iekšpusē #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Iezīmēt &amp;visu</value>
   </data>

--- a/NanaZipPackage/Strings/mk/Legacy.resw
+++ b/NanaZipPackage/Strings/mk/Legacy.resw
@@ -162,6 +162,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Излези</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Отвори Внатре *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Отвори Внатре #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Селектирај &amp;Се</value>
   </data>

--- a/NanaZipPackage/Strings/mn-cyrl/Legacy.resw
+++ b/NanaZipPackage/Strings/mn-cyrl/Legacy.resw
@@ -162,6 +162,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Га&amp;рах</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Дотор нээх *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Дотор нээх #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Бүгдийг со&amp;нгох</value>
   </data>

--- a/NanaZipPackage/Strings/mn-mong/Legacy.resw
+++ b/NanaZipPackage/Strings/mn-mong/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>ᠭᠠᠷᠬᠤ (&amp;X)</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>ᠣᠳᠣᠬᠢ ᠴᠣᠩᠬᠣ  ᠶᠢ ᠨᠡᠭᠡᠭᠡᠬᠦ *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>ᠣᠳᠣᠬᠢ ᠴᠣᠩᠬᠣ  ᠶᠢ ᠨᠡᠭᠡᠭᠡᠬᠦ #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>ᠪᠦᠬᠦᠨ  ᠢ ᠰᠣᠩᠭᠣᠬᠤ (&amp;A)</value>
   </data>

--- a/NanaZipPackage/Strings/mr/Legacy.resw
+++ b/NanaZipPackage/Strings/mr/Legacy.resw
@@ -162,6 +162,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>गमन</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>अंदर उघडा *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>अंदर उघडा #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>सर्व निवडा</value>
   </data>

--- a/NanaZipPackage/Strings/ms/Legacy.resw
+++ b/NanaZipPackage/Strings/ms/Legacy.resw
@@ -162,6 +162,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>K&amp;eluar</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Buka di Dalam *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Buka di Dalam #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Pilih &amp;Semua</value>
   </data>

--- a/NanaZipPackage/Strings/nb/Legacy.resw
+++ b/NanaZipPackage/Strings/nb/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Avslutt</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Åpne internt *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Åpne internt #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Merk &amp;alle</value>
   </data>

--- a/NanaZipPackage/Strings/ne/Legacy.resw
+++ b/NanaZipPackage/Strings/ne/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>निस्कनुहोस्</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>भित्रपट्टि खोल्नुहोस् *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>भित्रपट्टि खोल्नुहोस् #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>सबै चयन गर्नुहोस्</value>
   </data>

--- a/NanaZipPackage/Strings/nl/Legacy.resw
+++ b/NanaZipPackage/Strings/nl/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Sluiten</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Open binnen *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Open binnen #</value>
+  </data>
   <data name="Resource558" xml:space="preserve">
     <value>Koppeling</value>
   </data>

--- a/NanaZipPackage/Strings/nn/Legacy.resw
+++ b/NanaZipPackage/Strings/nn/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Avslutta</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Opna Inni *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Opna Inni #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>&amp;Merk alle</value>
   </data>

--- a/NanaZipPackage/Strings/pa-in/Legacy.resw
+++ b/NanaZipPackage/Strings/pa-in/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>ਬਾਹਰ ਨਿਕਲੋ (&amp;x)</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>ਅੰਦਰ ਖੋਲ੍ਹੋ *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>ਅੰਦਰ ਖੋਲ੍ਹੋ #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>ਸਭ ਚੁਣੋ (&amp;A)</value>
   </data>

--- a/NanaZipPackage/Strings/pl/Legacy.resw
+++ b/NanaZipPackage/Strings/pl/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Alternatywne strumienie</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Otwórz wewnątrz *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Otwórz wewnątrz #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Z&amp;aznacz wszystko</value>
   </data>

--- a/NanaZipPackage/Strings/ps/Legacy.resw
+++ b/NanaZipPackage/Strings/ps/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>و&amp;تون</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>دننه پرانيستل *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>دننه پرانيستل #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>ټول ټاکل&amp;</value>
   </data>

--- a/NanaZipPackage/Strings/pt-br/Legacy.resw
+++ b/NanaZipPackage/Strings/pt-br/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Correntes Alternantes</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Abrir por dentro *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Abrir por dentro #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Selecionar &amp;Tudo</value>
   </data>

--- a/NanaZipPackage/Strings/pt/Legacy.resw
+++ b/NanaZipPackage/Strings/pt/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Alternar fluxos</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Abrir dentro *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Abrir dentro #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Seleccionar &amp;tudo</value>
   </data>

--- a/NanaZipPackage/Strings/ro/Legacy.resw
+++ b/NanaZipPackage/Strings/ro/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>&amp;Ieşire</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Deschide în interior *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Deschide în interior #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>&amp;Selectează tot</value>
   </data>

--- a/NanaZipPackage/Strings/ru/Legacy.resw
+++ b/NanaZipPackage/Strings/ru/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Альтернативные потоки</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Открыть внутри *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Открыть внутри #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Выделить в&amp;се</value>
   </data>

--- a/NanaZipPackage/Strings/si/Legacy.resw
+++ b/NanaZipPackage/Strings/si/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;අනුකල්ප ප්‍රවාහ</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>මෙහිම විවෘත කරන්න *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>මෙහිම විවෘත කරන්න #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>&amp;සියල්ල තෝරන්න</value>
   </data>

--- a/NanaZipPackage/Strings/sk/Legacy.resw
+++ b/NanaZipPackage/Strings/sk/Legacy.resw
@@ -171,6 +171,12 @@
   <data name="Resource558" xml:space="preserve">
     <value>Odkaz...</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Otvoriť vnútri *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Otvoriť vnútri #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Označiť všetko</value>
   </data>

--- a/NanaZipPackage/Strings/sl/Legacy.resw
+++ b/NanaZipPackage/Strings/sl/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Nadomestni tokovi</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Odpri znotraj *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Odpri znotraj #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Izberi &amp;vse</value>
   </data>

--- a/NanaZipPackage/Strings/sq/Legacy.resw
+++ b/NanaZipPackage/Strings/sq/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Rrjedhat alternative të të dhënave</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Hap brenda *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Hap brenda #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Përzgjidh &amp;të gjithë</value>
   </data>

--- a/NanaZipPackage/Strings/sr-Latn/Legacy.resw
+++ b/NanaZipPackage/Strings/sr-Latn/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Izlaz</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Otvori iznutra *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Otvori iznutra #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Izaberi sve</value>
   </data>

--- a/NanaZipPackage/Strings/sr-cyrl/Legacy.resw
+++ b/NanaZipPackage/Strings/sr-cyrl/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Излаз</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Отвори изнутра *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Отвори изнутра #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Изабери све</value>
   </data>

--- a/NanaZipPackage/Strings/sv/Legacy.resw
+++ b/NanaZipPackage/Strings/sv/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Alternativa dataströmmar</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Öppna inuti *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Öppna inuti #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Markera &amp;alla</value>
   </data>

--- a/NanaZipPackage/Strings/sw/Legacy.resw
+++ b/NanaZipPackage/Strings/sw/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Mitiririsho mbadala</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Fungua Ndani *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Fungua Ndani #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Teua &amp;zote</value>
   </data>

--- a/NanaZipPackage/Strings/ta/Legacy.resw
+++ b/NanaZipPackage/Strings/ta/Legacy.resw
@@ -156,6 +156,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>வெளியேறு</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>உள்ளே திற *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>உள்ளே திற #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>அனைத்தும் தேர்ந்தெடு</value>
   </data>

--- a/NanaZipPackage/Strings/tg-arab/Legacy.resw
+++ b/NanaZipPackage/Strings/tg-arab/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Ҷараёнҳои алтернативӣ</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Кушодан аз дарун *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Кушодан аз дарун #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Ҳамаашро интихоб кардан</value>
   </data>

--- a/NanaZipPackage/Strings/th/Legacy.resw
+++ b/NanaZipPackage/Strings/th/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>ออก</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>เปิดภายใน *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>เปิดภายใน #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>เลือกทั้งหมด</value>
   </data>

--- a/NanaZipPackage/Strings/tk-cyrl/Legacy.resw
+++ b/NanaZipPackage/Strings/tk-cyrl/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>Akymlary ç&amp;alyş</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Içinde Aç *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Içinde Aç #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Hemmesini Seç</value>
   </data>

--- a/NanaZipPackage/Strings/tr/Legacy.resw
+++ b/NanaZipPackage/Strings/tr/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>Akış&amp;ları Değiştir</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>NanaZip İçinde Aç *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>NanaZip İçinde Aç #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Tümünü &amp;Seç</value>
   </data>

--- a/NanaZipPackage/Strings/tt-arab/Legacy.resw
+++ b/NanaZipPackage/Strings/tt-arab/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Альтернатив Агымнар</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Эчкә ачарга *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Эчкә ачарга #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Б&amp;өтенесен билгеләргә</value>
   </data>

--- a/NanaZipPackage/Strings/ug-arab/Legacy.resw
+++ b/NanaZipPackage/Strings/ug-arab/Legacy.resw
@@ -165,6 +165,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>چېكىن(&amp;X)</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>نۆۋەتتىكى كۆزنەكتە ئاچ *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>نۆۋەتتىكى كۆزنەكتە ئاچ #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>ھەممىنى تاللا(&amp;A)</value>
   </data>

--- a/NanaZipPackage/Strings/uk/Legacy.resw
+++ b/NanaZipPackage/Strings/uk/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>Ал&amp;ьтернативні потоки</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Відкрити всередині *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Відкрити всередині #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Ви&amp;брати все</value>
   </data>

--- a/NanaZipPackage/Strings/uz-cyrl/Legacy.resw
+++ b/NanaZipPackage/Strings/uz-cyrl/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Муқобил оқимлар</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Ичкарида очмоқ *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Ичкарида очмоқ #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>&amp;Барини танламоқ</value>
   </data>

--- a/NanaZipPackage/Strings/uz-latn/Legacy.resw
+++ b/NanaZipPackage/Strings/uz-latn/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Muqobil oqimlar</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Ichkarida ochmoq *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Ichkarida ochmoq #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>&amp;Barini tanlamoq</value>
   </data>

--- a/NanaZipPackage/Strings/vi/Legacy.resw
+++ b/NanaZipPackage/Strings/vi/Legacy.resw
@@ -168,6 +168,12 @@
   <data name="Resource557" xml:space="preserve">
     <value>Thoát</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Mở tại đây *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Mở tại đây #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Chọn tất cả</value>
   </data>

--- a/NanaZipPackage/Strings/yo-latn/Legacy.resw
+++ b/NanaZipPackage/Strings/yo-latn/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>&amp;Yiyan agbara détà</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>Ṣi si ínú *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>Ṣi si ínú #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>Àṣàyàn &amp;gbogbo faíli</value>
   </data>

--- a/NanaZipPackage/Strings/zh-Hans/Legacy.resw
+++ b/NanaZipPackage/Strings/zh-Hans/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>交替数据流(&amp;A)</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>当前窗口打开 *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>当前窗口打开 #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>全选(&amp;A)</value>
   </data>

--- a/NanaZipPackage/Strings/zh-Hant/Legacy.resw
+++ b/NanaZipPackage/Strings/zh-Hant/Legacy.resw
@@ -174,6 +174,12 @@
   <data name="Resource559" xml:space="preserve">
     <value>附加資料流(&amp;A)</value>
   </data>
+  <data name="Resource590" xml:space="preserve">
+    <value>在內部開啟 *</value>
+  </data>
+  <data name="Resource591" xml:space="preserve">
+    <value>在內部開啟 #</value>
+  </data>
   <data name="Resource600" xml:space="preserve">
     <value>全選(&amp;A)</value>
   </data>


### PR DESCRIPTION
The EN text of Open Inside */# were replaced with "Open Inside (One level)" and "Open Inside (Parser)". The rest simply had */# appended like before.

<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Documents/Security.md.
-->
