### PR TITLE
Fix UI assignment of WriteZone setting

### DIFF
--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
@@ -226,7 +226,12 @@ LONG CMenuPage::OnApply()
 
     {
       int zoneIndex = (int)_zoneCombo.GetItemData_of_CurSel();
-      if (zoneIndex <= 0)
+      // **************** NanaZip Modification Start ****************
+      // if (zoneIndex <= 0)
+      if (zoneIndex < 0 ||
+          zoneIndex > NExtract::NZoneIdMode::kOffice ||
+          zoneIndex == NExtract::NZoneIdMode::Default)
+      // **************** NanaZip Modification End ****************
         zoneIndex = -1;
       ci.WriteZone = (UInt32)(Int32)zoneIndex;
     }

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/MenuPage.cpp
@@ -226,7 +226,12 @@ LONG CMenuPage::OnApply()
 
     {
       int zoneIndex = (int)_zoneCombo.GetItemData_of_CurSel();
-      if (zoneIndex <= 0)
+      // **************** NanaZip Modification Start ****************
+      // if (zoneIndex <= 0)
+      if (zoneIndex < 0 ||
+          zoneIndex > NExtract::NZoneIdMode::kOffice ||
+          zoneIndex == NExtract::NZoneIdMode::Default)
+      // **************** NanaZip Modification End ****************
         zoneIndex = -1;
       ci.WriteZone = (UInt32)(Int32)zoneIndex;
     }


### PR DESCRIPTION
Fixes the inability to set the MOTW zone option to No in NanaZip settings dialog.

<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Documents/Security.md.
-->