### PR TITLE
Fix error handling of NanaZip.Codecs

### DIFF
--- a/NanaZip.Codecs/NanaZip.Codecs.Archive.DotNetSingleFile.cpp
+++ b/NanaZip.Codecs/NanaZip.Codecs.Archive.DotNetSingleFile.cpp
@@ -475,7 +475,7 @@ namespace NanaZip::Codecs::Archive
 
             } while (false);
 
-            if (FAILED(hr))
+            if (hr != S_OK)
             {
                 this->Close();
             }
@@ -670,14 +670,15 @@ namespace NanaZip::Codecs::Archive
             _In_ PROPID PropId,
             _Inout_ LPPROPVARIANT Value)
         {
-            if (!this->m_IsInitialized)
-            {
-                return S_FALSE;
-            }
-
             if (!Value)
             {
                 return E_INVALIDARG;
+            }
+
+            if (!this->m_IsInitialized)
+            {
+                Value->vt = VT_EMPTY;
+                return S_OK;
             }
 
             switch (PropId)

--- a/NanaZip.Codecs/NanaZip.Codecs.Archive.ElectronAsar.cpp
+++ b/NanaZip.Codecs/NanaZip.Codecs.Archive.ElectronAsar.cpp
@@ -259,7 +259,7 @@ namespace NanaZip::Codecs::Archive
 
             } while (false);
 
-            if (FAILED(hr))
+            if (hr != S_OK)
             {
                 this->Close();
             }
@@ -451,14 +451,15 @@ namespace NanaZip::Codecs::Archive
             _In_ PROPID PropId,
             _Inout_ LPPROPVARIANT Value)
         {
-            if (!this->m_IsInitialized)
-            {
-                return S_FALSE;
-            }
-
             if (!Value)
             {
                 return E_INVALIDARG;
+            }
+
+            if (!this->m_IsInitialized)
+            {
+                Value->vt = VT_EMPTY;
+                return S_OK;
             }
 
             switch (PropId)

--- a/NanaZip.Codecs/NanaZip.Codecs.Archive.Littlefs.cpp
+++ b/NanaZip.Codecs/NanaZip.Codecs.Archive.Littlefs.cpp
@@ -648,7 +648,7 @@ namespace NanaZip::Codecs::Archive
 
             } while (false);
 
-            if (FAILED(hr))
+            if (hr != S_OK)
             {
                 this->Close();
             }
@@ -855,14 +855,15 @@ namespace NanaZip::Codecs::Archive
             _In_ PROPID PropId,
             _Inout_ LPPROPVARIANT Value)
         {
-            if (!this->m_IsInitialized)
-            {
-                return S_FALSE;
-            }
-
             if (!Value)
             {
                 return E_INVALIDARG;
+            }
+
+            if (!this->m_IsInitialized)
+            {
+                Value->vt = VT_EMPTY;
+                return S_OK;
             }
 
             switch (PropId)

--- a/NanaZip.Codecs/NanaZip.Codecs.Archive.Romfs.cpp
+++ b/NanaZip.Codecs/NanaZip.Codecs.Archive.Romfs.cpp
@@ -362,7 +362,7 @@ namespace NanaZip::Codecs::Archive
 
             } while (false);
 
-            if (FAILED(hr))
+            if (hr != S_OK)
             {
                 this->Close();
             }
@@ -622,14 +622,15 @@ namespace NanaZip::Codecs::Archive
             _In_ PROPID PropId,
             _Inout_ LPPROPVARIANT Value)
         {
-            if (!this->m_IsInitialized)
-            {
-                return S_FALSE;
-            }
-
             if (!Value)
             {
                 return E_INVALIDARG;
+            }
+
+            if (!this->m_IsInitialized)
+            {
+                Value->vt = VT_EMPTY;
+                return S_OK;
             }
 
             switch (PropId)

--- a/NanaZip.Codecs/NanaZip.Codecs.Archive.Ufs.cpp
+++ b/NanaZip.Codecs/NanaZip.Codecs.Archive.Ufs.cpp
@@ -773,7 +773,7 @@ namespace NanaZip::Codecs::Archive
 
             } while (false);
 
-            if (FAILED(hr))
+            if (hr != S_OK)
             {
                 this->Close();
             }
@@ -1113,14 +1113,15 @@ namespace NanaZip::Codecs::Archive
             _In_ PROPID PropId,
             _Inout_ LPPROPVARIANT Value)
         {
-            if (!this->m_IsInitialized)
-            {
-                return S_FALSE;
-            }
-
             if (!Value)
             {
                 return E_INVALIDARG;
+            }
+
+            if (!this->m_IsInitialized)
+            {
+                Value->vt = VT_EMPTY;
+                return S_OK;
             }
 
             switch (PropId)

--- a/NanaZip.Codecs/NanaZip.Codecs.Archive.WebAssembly.cpp
+++ b/NanaZip.Codecs/NanaZip.Codecs.Archive.WebAssembly.cpp
@@ -341,7 +341,7 @@ namespace NanaZip::Codecs::Archive
 
             } while (false);
 
-            if (FAILED(hr))
+            if (hr != S_OK)
             {
                 this->Close();
             }
@@ -537,14 +537,15 @@ namespace NanaZip::Codecs::Archive
             _In_ PROPID PropId,
             _Inout_ LPPROPVARIANT Value)
         {
-            if (!this->m_IsInitialized)
-            {
-                return S_FALSE;
-            }
-
             if (!Value)
             {
                 return E_INVALIDARG;
+            }
+
+            if (!this->m_IsInitialized)
+            {
+                Value->vt = VT_EMPTY;
+                return S_OK;
             }
 
             switch (PropId)

--- a/NanaZip.Codecs/NanaZip.Codecs.Archive.Zealfs.cpp
+++ b/NanaZip.Codecs/NanaZip.Codecs.Archive.Zealfs.cpp
@@ -328,7 +328,7 @@ namespace NanaZip::Codecs::Archive
 
             } while (false);
 
-            if (FAILED(hr))
+            if (hr != S_OK)
             {
                 this->Close();
             }
@@ -564,14 +564,15 @@ namespace NanaZip::Codecs::Archive
             _In_ PROPID PropId,
             _Inout_ LPPROPVARIANT Value)
         {
-            if (!this->m_IsInitialized)
-            {
-                return S_FALSE;
-            }
-
             if (!Value)
             {
                 return E_INVALIDARG;
+            }
+
+            if (!this->m_IsInitialized)
+            {
+                Value->vt = VT_EMPTY;
+                return S_OK;
             }
 
             switch (PropId)


### PR DESCRIPTION
- S_FALSE during Open() should also clean up the handler.
- GetArchiveProperty should return VT_EMPTY instead of failing when an archive is not opened, since it will otherwise interfere with update workflows, where UpdateArchive calls GetArchiveProperty on the handler's error props.

<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Documents/Security.md.
-->
