### PR TITLE
Tweak margins of address bar elements

### DIFF
--- a/NanaZip.Modern/AddressBarTemplate.xaml
+++ b/NanaZip.Modern/AddressBarTemplate.xaml
@@ -4,7 +4,7 @@
   xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
   xmlns:local="using:NanaZip.Modern">
 
-  <Thickness x:Key="AddressBarImageIconMargin">8,4,0,4</Thickness>
+  <Thickness x:Key="AddressBarImageIconMargin">8,2,0,6</Thickness>
 
   <DataTemplate x:Key="DefaultAddressBarItemTemplate" x:DataType="local:AddressBarItem">
     <StackPanel
@@ -197,7 +197,7 @@
                     <ControlTemplate TargetType="Button">
                       <Grid
                         x:Name="ButtonLayoutGrid"
-                        Margin="{ThemeResource TextBoxInnerButtonMargin}"
+                        Margin="2,4,4,8"
                         Background="{ThemeResource TextControlButtonBackground}"
                         BackgroundSizing="{TemplateBinding BackgroundSizing}"
                         BorderBrush="{ThemeResource TextControlButtonBorderBrush}"


### PR DESCRIPTION
The folder icon and dropdown button were having incorrect margins.

<img width="83" height="52" alt="image" src="https://github.com/user-attachments/assets/11606d6e-ac5b-47a2-94b2-ce2abe59e715" />

<img width="234" height="76" alt="image" src="https://github.com/user-attachments/assets/1bc1dac2-cefa-4963-bd60-d218d4d44ea2" />

After:

<img width="118" height="57" alt="image" src="https://github.com/user-attachments/assets/c94eb09e-a24a-487b-ab90-caa75847aa82" />

﻿<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Security.md.
-->
