### PR TITLE
Fix integer underflow in WebAssembly section size computation

### DIFF
--- a/NanaZip.Codecs/NanaZip.Codecs.Archive.WebAssembly.cpp
+++ b/NanaZip.Codecs/NanaZip.Codecs.Archive.WebAssembly.cpp
@@ -292,6 +292,10 @@ namespace NanaZip::Codecs::Archive
                                 Buffer,
                                 &ProcessedBytes);
                             i += ProcessedBytes;
+                            if (Size < ProcessedBytes)
+                            {
+                                break;
+                            }
                             Size -= ProcessedBytes;
                         }
                         if (NameSize)
@@ -305,6 +309,10 @@ namespace NanaZip::Codecs::Archive
                                 break;
                             }
                             i += sizeof(char) * NameSize;
+                            if (Size < sizeof(char) * NameSize)
+                            {
+                                break;
+                            }
                             Size -= sizeof(char) * NameSize;
                         }
                     }


### PR DESCRIPTION
This is not a security fix.
An unsigned integer underflow in the WebAssembly binary format parser. When parsing a custom section, the handler subtracts `ProcessedBytes` and `NameSize` from the section `Size` field without checking for underflow. The wrapped `uint32_t` value (~4 GB) is stored as the section's payload size and later used as an allocation size during extraction and may cause out-of-memory or creation of a up to 4GB output file (filled with zeroes, no heap information).
