### PR TITLE
release/6.0: Fix integer underflow in WebAssembly section size computation

### DIFF
--- a/NanaZip.Codecs/NanaZip.Codecs.Archive.WebAssembly.cpp
+++ b/NanaZip.Codecs/NanaZip.Codecs.Archive.WebAssembly.cpp
@@ -292,6 +292,10 @@ namespace NanaZip::Codecs::Archive
                                 Buffer,
                                 &ProcessedBytes);
                             i += ProcessedBytes;
+                            if (Size < ProcessedBytes)
+                            {
+                                break;
+                            }
                             Size -= ProcessedBytes;
                         }
                         if (NameSize)
@@ -305,6 +309,10 @@ namespace NanaZip::Codecs::Archive
                                 break;
                             }
                             i += sizeof(char) * NameSize;
+                            if (Size < sizeof(char) * NameSize)
+                            {
+                                break;
+                            }
                             Size -= sizeof(char) * NameSize;
                         }
                     }


### PR DESCRIPTION
(cherry picked from commit 7b8e8f1e0b681e330036f6f97de309b2b6631dce)

﻿<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Security.md.
-->
