### PR TITLE
Set COMMIT_EDITMSG file to UTF8 without BOM

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -71,3 +71,6 @@ indent_style = space
 indent_size = 4
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[COMMIT_EDITMSG]
+charset = utf-8


### PR DESCRIPTION
Otherwise, the BOM gets interpreted as part of the commit message.

﻿<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Security.md.
-->
