### PR TITLE
Don't open Explorer by default during extract-on-open

### DIFF
--- a/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
+++ b/NanaZip.UI.Classic/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
@@ -501,7 +501,6 @@ static bool CallExtractOnOpen() {
     false,
     false,
     ci.WriteZone,
-    true,
     true);
   return true;
 }

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
@@ -497,7 +497,6 @@ static bool CallExtractOnOpen() {
     false,
     false,
     ci.WriteZone,
-    true,
     true);
   return true;
 }


### PR DESCRIPTION
Opening Explorer after extract-on-open ended up causing multiple requests to turn it off.

In the absence of another config option, do like Linux archivers do and don't open any Explorer window after extract-on-open.