### PR TITLE
NanaZip.ShellExtension: Fix EnumSubCommands refcount leak

### DIFF
--- a/NanaZip.UI.Modern/NanaZip.ShellExtension.cpp
+++ b/NanaZip.UI.Modern/NanaZip.ShellExtension.cpp
@@ -1006,7 +1006,6 @@ namespace NanaZip::ShellExtension
             else
             {
                 this->m_CurrentSubCommand = this->m_SubCommands.cbegin();
-                this->AddRef();
                 return this->QueryInterface(IID_PPV_ARGS(ppEnum));
             }
         }


### PR DESCRIPTION
(For main+stable)

QueryInterface already does an AddRef. Remove the unnecessary manual AddRef.

﻿<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Security.md.
-->
