### PR TITLE
Add "Smart Extract and Open" toolbar button to File Manager

### DIFF
--- a/NanaZip.Modern/MainWindowToolBarPage.cpp
+++ b/NanaZip.Modern/MainWindowToolBarPage.cpp
@@ -270,6 +270,7 @@ namespace
             Add = 1070,
             Extract = 1071,
             Test = 1072,
+            SmartExtract = 1073, // = kMenuCmdID_Toolbar_SmartExtract (App.h)
             Copy = 546,
             Move = 547,
             Delete = 548,
@@ -416,6 +417,22 @@ namespace winrt::NanaZip::Modern::implementation
             WM_COMMAND,
             MAKEWPARAM(
                 ToolBarCommandID::Test,
+                BN_CLICKED),
+            0);
+    }
+
+    void MainWindowToolBarPage::SmartExtractButtonClick(
+        winrt::IInspectable const& sender,
+        winrt::RoutedEventArgs const& e)
+    {
+        UNREFERENCED_PARAMETER(sender);
+        UNREFERENCED_PARAMETER(e);
+
+        ::PostMessageW(
+            this->m_WindowHandle,
+            WM_COMMAND,
+            MAKEWPARAM(
+                ToolBarCommandID::SmartExtract,
                 BN_CLICKED),
             0);
     }

--- a/NanaZip.Modern/MainWindowToolBarPage.h
+++ b/NanaZip.Modern/MainWindowToolBarPage.h
@@ -42,6 +42,10 @@ namespace winrt::NanaZip::Modern::implementation
             winrt::IInspectable const& sender,
             winrt::RoutedEventArgs const& e);
 
+        void SmartExtractButtonClick(
+            winrt::IInspectable const& sender,
+            winrt::RoutedEventArgs const& e);
+
         void CopyButtonClick(
             winrt::IInspectable const& sender,
             winrt::RoutedEventArgs const& e);

--- a/NanaZip.Modern/MainWindowToolBarPage.xaml
+++ b/NanaZip.Modern/MainWindowToolBarPage.xaml
@@ -47,6 +47,17 @@
           Click="TestButtonClick"
           Icon="Accept"
           ToolTipService.ToolTip="[Test]" />
+        <AppBarButton
+          x:Uid="/NanaZip.Modern/MainWindowToolBarPage/SmartExtractButton"
+          x:Name="SmartExtractButton"
+          Width="48"
+          AutomationProperties.Name="[Smart Extract and Open]"
+          Click="SmartExtractButtonClick"
+          ToolTipService.ToolTip="[Smart Extract and Open]">
+          <AppBarButton.Content>
+            <TextBlock FontFamily="Segoe MDL2 Assets" Text="&#xE8DA;" />
+          </AppBarButton.Content>
+        </AppBarButton>
         <AppBarSeparator />
         <AppBarButton
           x:Name="CopyButton"

--- a/NanaZip.Modern/Strings/de/MainWindowToolBarPage.resw
+++ b/NanaZip.Modern/Strings/de/MainWindowToolBarPage.resw
@@ -125,6 +125,14 @@
     <value>Mehr</value>
     <comment>More</comment>
   </data>
+  <data name="SmartExtractButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
+  <data name="SmartExtractButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
   <data name="SponsorButton.AcquireText" xml:space="preserve">
     <value>NanaZip unterstützen</value>
     <comment>Sponsor NanaZip</comment>

--- a/NanaZip.Modern/Strings/el/MainWindowToolBarPage.resw
+++ b/NanaZip.Modern/Strings/el/MainWindowToolBarPage.resw
@@ -125,6 +125,14 @@
     <value>Περισσότερα</value>
     <comment>More</comment>
   </data>
+  <data name="SmartExtractButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
+  <data name="SmartExtractButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
   <data name="SponsorButton.AcquireText" xml:space="preserve">
     <value>Δωρεά στο NanaZip</value>
     <comment>Sponsor NanaZip</comment>

--- a/NanaZip.Modern/Strings/en/MainWindowToolBarPage.resw
+++ b/NanaZip.Modern/Strings/en/MainWindowToolBarPage.resw
@@ -125,6 +125,14 @@
     <value>More</value>
     <comment>More</comment>
   </data>
+  <data name="SmartExtractButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
+  <data name="SmartExtractButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
   <data name="SponsorButton.AcquireText" xml:space="preserve">
     <value>Sponsor NanaZip</value>
     <comment>Sponsor NanaZip</comment>

--- a/NanaZip.Modern/Strings/hu/MainWindowToolBarPage.resw
+++ b/NanaZip.Modern/Strings/hu/MainWindowToolBarPage.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
 	<!-- 
     Microsoft ResX Schema 
@@ -124,6 +124,14 @@
 	<data name="MoreButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Továbbiak</value>
     <comment>More</comment>
+  </data>
+	<data name="SmartExtractButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
+	<data name="SmartExtractButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
   </data>
 	<data name="SponsorButton.AcquireText" xml:space="preserve">
     <value>NanaZip támogatása</value>

--- a/NanaZip.Modern/Strings/nl/MainWindowToolBarPage.resw
+++ b/NanaZip.Modern/Strings/nl/MainWindowToolBarPage.resw
@@ -125,6 +125,14 @@
     <value>Meer</value>
     <comment>More</comment>
   </data>
+  <data name="SmartExtractButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
+  <data name="SmartExtractButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
   <data name="SponsorButton.AcquireText" xml:space="preserve">
     <value>Sponsor NanaZip</value>
     <comment>Sponsor NanaZip</comment>

--- a/NanaZip.Modern/Strings/pl/MainWindowToolBarPage.resw
+++ b/NanaZip.Modern/Strings/pl/MainWindowToolBarPage.resw
@@ -125,6 +125,14 @@
     <value>Więcej</value>
     <comment>More</comment>
   </data>
+  <data name="SmartExtractButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
+  <data name="SmartExtractButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
   <data name="SponsorButton.AcquireText" xml:space="preserve">
     <value>Zostań sponsorem NanaZip</value>
     <comment>Sponsor NanaZip</comment>

--- a/NanaZip.Modern/Strings/pt-BR/MainWindowToolBarPage.resw
+++ b/NanaZip.Modern/Strings/pt-BR/MainWindowToolBarPage.resw
@@ -125,6 +125,14 @@
     <value>Mais</value>
     <comment>More</comment>
   </data>
+  <data name="SmartExtractButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
+  <data name="SmartExtractButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
   <data name="SponsorButton.AcquireText" xml:space="preserve">
     <value>Patrocinar NanaZip</value>
     <comment>Sponsor NanaZip</comment>

--- a/NanaZip.Modern/Strings/sq/MainWindowToolBarPage.resw
+++ b/NanaZip.Modern/Strings/sq/MainWindowToolBarPage.resw
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!-- 
     Microsoft ResX Schema 
@@ -124,6 +124,14 @@
   <data name="MoreButton.ToolTipService.ToolTip" xml:space="preserve">
     <value>Më shumë</value>
     <comment>More</comment>
+  </data>
+  <data name="SmartExtractButton.AutomationProperties.Name" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
+  <data name="SmartExtractButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>Smart Extract and Open</value>
+    <comment>Smart Extract and Open</comment>
   </data>
   <data name="SponsorButton.AcquireText" xml:space="preserve">
     <value>Mbështet NanaZip</value>

--- a/NanaZip.Modern/Strings/zh-Hans/MainWindowToolBarPage.resw
+++ b/NanaZip.Modern/Strings/zh-Hans/MainWindowToolBarPage.resw
@@ -125,6 +125,14 @@
     <value>更多</value>
     <comment>More</comment>
   </data>
+  <data name="SmartExtractButton.AutomationProperties.Name" xml:space="preserve">
+    <value>智能解压并打开</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
+  <data name="SmartExtractButton.ToolTipService.ToolTip" xml:space="preserve">
+    <value>智能解压并打开</value>
+    <comment>Smart Extract and Open</comment>
+  </data>
   <data name="SponsorButton.AcquireText" xml:space="preserve">
     <value>赞助 NanaZip</value>
     <comment>Sponsor NanaZip</comment>

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/App.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/App.h
@@ -27,6 +27,9 @@ enum
   kMenuCmdID_Toolbar_Add = kMenuCmdID_Toolbar_Start,
   kMenuCmdID_Toolbar_Extract,
   kMenuCmdID_Toolbar_Test,
+  // **************** NanaZip Modification Start ****************
+  kMenuCmdID_Toolbar_SmartExtract,
+  // **************** NanaZip Modification End ****************
   kMenuCmdID_Toolbar_End
 };
 
@@ -313,6 +316,9 @@ public:
   void AddToArchive() { GetFocusedPanel().AddToArchive(); }
   void ExtractArchives() { GetFocusedPanel().ExtractArchives(); }
   void TestArchives() { GetFocusedPanel().TestArchives(); }
+  // **************** NanaZip Modification Start ****************
+  bool SmartExtractArchives() { return GetFocusedPanel().SmartExtractArchives(); }
+  // **************** NanaZip Modification End ****************
 
   void OnNotify(int ctrlID, LPNMHDR pnmh);
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/FM.cpp
@@ -853,6 +853,12 @@ static void ExecuteCommand(UINT commandID)
     case kMenuCmdID_Toolbar_Add: g_App.AddToArchive(); break;
     case kMenuCmdID_Toolbar_Extract: g_App.ExtractArchives(); break;
     case kMenuCmdID_Toolbar_Test: g_App.TestArchives(); break;
+    // **************** NanaZip Modification Start ****************
+    case kMenuCmdID_Toolbar_SmartExtract:
+      if (g_App.SmartExtractArchives())
+        ::PostMessage(g_HWND, WM_CLOSE, 0, 0);
+      break;
+    // **************** NanaZip Modification End ****************
   }
 }
 

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.cpp
@@ -1342,6 +1342,55 @@ void CPanel::ExtractFromArchive()
       );
 }
 
+// **************** NanaZip Modification Start ****************
+bool CPanel::SmartExtractArchives()
+{
+  UStringVector paths;
+  UString outFolder;
+
+  if (_parentFolders.Size() > 0)
+  {
+    const CFolderLink &fl = _parentFolders[0];
+    if (fl.IsVirtual || fl.VirtualPath.IsEmpty() || fl.ParentFolderPath.IsEmpty())
+    {
+      MessageBox_Error_UnsupportOperation();
+      return false;
+    }
+    paths.Add(fl.VirtualPath);
+    outFolder = fl.ParentFolderPath;
+  }
+  else
+  {
+    if (!IsFSFolder())
+    {
+      MessageBox_Error_UnsupportOperation();
+      return false;
+    }
+    CRecordVector<UInt32> indices;
+    GetOperatedItemIndices(indices);
+    GetFilePaths(indices, paths);
+    if (paths.IsEmpty())
+      return false;
+    outFolder = GetFsPath();
+  }
+
+  if (outFolder.IsEmpty())
+    return false;
+
+  CContextMenuInfo ci;
+  ci.Load();
+
+  ::ExtractArchives(paths, outFolder
+      , false // showDialog
+      , false // elimDup
+      , ci.WriteZone
+      , true // smartExtract
+      , true // openFolder
+      );
+  return true;
+}
+// **************** NanaZip Modification End ****************
+
 /*
 static void AddValuePair(UINT resourceID, UInt64 value, UString &s)
 {

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.h
@@ -895,6 +895,9 @@ public:
   void ExtractArchives();
   void ExtractFromArchive();
   void TestArchives();
+  // **************** NanaZip Modification Start ****************
+  bool SmartExtractArchives();
+  // **************** NanaZip Modification End ****************
 
   // **************** NanaZip Modification Start ****************
   // Backported from 24.09.


### PR DESCRIPTION
Adds a one-click File Manager toolbar button that smart-extracts the selected archive (or, when browsing inside an archive, that archive) into the current directory, opens the output folder, and closes the NanaZip window.

Extraction is launched out of process (`showDialog=false`, `smartExtract=true`, `openFolder=true`), so it runs in a separate `NanaZip.Universal.Windows.exe` that opens the output folder on success; closing the File Manager window does not interrupt it.

The button label is localized for en / zh-Hans / zh-Hant; other languages fall back to en.