### PR TITLE
Fix capitalization in PackedSizeLabel text

### DIFF
--- a/NanaZip.Modern/Strings/pt-BR/ProgressPage.resw
+++ b/NanaZip.Modern/Strings/pt-BR/ProgressPage.resw
@@ -64,7 +64,7 @@
     <value>Arquivos</value>
   </data>
   <data name="PackedSizeLabel.Text" xml:space="preserve">
-    <value>Tamanho Compactado</value>
+    <value>Tamanho compactado</value>
   </data>
   <data name="BackgroundButtonText" xml:space="preserve">
     <value>Em 2º plano</value>


### PR DESCRIPTION
Fix capitalization in PackedSizeLabel text

﻿<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Security.md.
-->
