### PR TITLE
ElectronAsar: Fix invalid offset used for entry extraction

### DIFF
--- a/NanaZip.Codecs/NanaZip.Codecs.Archive.ElectronAsar.cpp
+++ b/NanaZip.Codecs/NanaZip.Codecs.Archive.ElectronAsar.cpp
@@ -464,7 +464,7 @@ namespace NanaZip::Codecs::Archive
                 UINT64 ActualOffset;
 
                 if (FAILED(this->m_FileStream->Seek(
-                    Information.Offset,
+                    this->m_GlobalOffset + Information.Offset,
                     STREAM_SEEK_SET,
                     &ActualOffset)))
                 {


### PR DESCRIPTION
Noticed this while trying to extract an ASAR, seems like this got accidentally changed in 0d98479.

Thanks for creating + maintaining the tool!