### PR TITLE
Compatibility fix for Sogou Pinyin

### DIFF
--- a/K7Base/K7BaseInitialize.cpp
+++ b/K7Base/K7BaseInitialize.cpp
@@ -26,13 +26,13 @@ EXTERN_C MO_RESULT MOAPI K7BaseInitialize()
         return Result;
     }
 
-    Result = ::K7BaseEnableMandatoryMitigations();
+    Result = ::K7BaseInitializeDynamicLinkLibraryBlocker();
     if (MO_RESULT_SUCCESS_OK != Result)
     {
         return Result;
     }
 
-    Result = ::K7BaseInitializeDynamicLinkLibraryBlocker();
+    Result = ::K7BaseEnableMandatoryMitigations();
     if (MO_RESULT_SUCCESS_OK != Result)
     {
         return Result;

--- a/K7Base/K7BaseMitigations.cpp
+++ b/K7Base/K7BaseMitigations.cpp
@@ -211,11 +211,15 @@ namespace
      */
     const ModuleItem g_ModuleRules[] =
     {
+        // iFlyIME
         { ModuleTypes::NeedsDynamicCodeOptout, "BaseGUI.dll" },
+        // Explorer Patcher
         { ModuleTypes::NeedsBlocking, "ExplorerPatcher.amd64.dll" },
         { ModuleTypes::NeedsBlocking, "ExplorerPatcher.IA-32.dll" },
+        // Proxifier
         { ModuleTypes::NeedsBlocking, "PrxDrvPE.dll" },
         { ModuleTypes::NeedsBlocking, "PrxDrvPE64.dll" },
+        // TranslucentFlyouts
         { ModuleTypes::NeedsBlocking, "TFMain32.dll" },
         { ModuleTypes::NeedsBlocking, "TFMain64.dll" },
     };

--- a/K7Base/K7BaseMitigations.cpp
+++ b/K7Base/K7BaseMitigations.cpp
@@ -219,6 +219,8 @@ namespace
         // Proxifier
         { ModuleTypes::NeedsBlocking, "PrxDrvPE.dll" },
         { ModuleTypes::NeedsBlocking, "PrxDrvPE64.dll" },
+        // Sogou Pinyin
+        { ModuleTypes::NeedsDynamicCodeOptout, "SogouPY.ime" },
         // TranslucentFlyouts
         { ModuleTypes::NeedsBlocking, "TFMain32.dll" },
         { ModuleTypes::NeedsBlocking, "TFMain64.dll" },

--- a/K7Base/K7BaseMitigations.cpp
+++ b/K7Base/K7BaseMitigations.cpp
@@ -652,7 +652,9 @@ namespace
             dwSize,
             flAllocationType,
             flProtect);
+        DWORD Error = ::GetLastError();
         ::K7BaseSetCurrentThreadDynamicCodePolicyOptOut(MO_FALSE);
+        ::SetLastError(Error);
         return Result;
     }
 
@@ -681,7 +683,9 @@ namespace
             dwSize,
             flAllocationType,
             flProtect);
+        DWORD Error = ::GetLastError();
         ::K7BaseSetCurrentThreadDynamicCodePolicyOptOut(MO_FALSE);
+        ::SetLastError(Error);
         return Result;
     }
 
@@ -706,7 +710,9 @@ namespace
             dwSize,
             flNewProtect,
             lpflOldProtect);
+        DWORD Error = ::GetLastError();
         ::K7BaseSetCurrentThreadDynamicCodePolicyOptOut(MO_FALSE);
+        ::SetLastError(Error);
         return Result;
     }
 
@@ -735,7 +741,9 @@ namespace
             dwSize,
             flNewProtect,
             lpflOldProtect);
+        DWORD Error = ::GetLastError();
         ::K7BaseSetCurrentThreadDynamicCodePolicyOptOut(MO_FALSE);
+        ::SetLastError(Error);
         return Result;
     }
 


### PR DESCRIPTION
https://github.com/M2Team/NanaZip/issues/946 and likely https://github.com/M2Team/NanaZip/issues/936 were caused by an incompatibility issue with the SogouPY.ime module. If this module failed its VirtualProtect call, it will cause the parent process to exit without any error messages or crash dumps. Add a dynamic code optout for this module.

The DLL blocker was also having a regression where it was initialized after the general mitigations, which should not happen.

﻿<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Security.md.
-->
