### PR TITLE
Ingore accent color if creating K7ModernXamlDialog with backdrop

### DIFF
--- a/NanaZip.Modern/NanaZip.Modern.cpp
+++ b/NanaZip.Modern/NanaZip.Modern.cpp
@@ -229,10 +229,26 @@ namespace
     HWND K7ModernCreateXamlDialog(
         _In_opt_ HWND ParentWindowHandle)
     {
-        return ::K7ModernCreateXamlWindow(
+        HWND DialogHandle= ::K7ModernCreateXamlWindow(
             ParentWindowHandle,
             WS_EX_STATICEDGE | WS_EX_DLGMODALFRAME,
             WS_CAPTION | WS_SYSMENU);
+
+        MILE_WINDOW_SYSTEM_BACKDROP_TYPE BackdropType =
+            MILE_WINDOW_SYSTEM_BACKDROP_TYPE_AUTO;
+        if (S_OK == ::MileGetWindowSystemBackdropTypeAttribute(
+                DialogHandle,
+                &BackdropType) &&
+            BackdropType != MILE_WINDOW_SYSTEM_BACKDROP_TYPE_AUTO &&
+            BackdropType != MILE_WINDOW_SYSTEM_BACKDROP_TYPE_NONE)
+        {
+            COLORREF IgnoreAccentColor = static_cast<COLORREF>(-2);
+            ::MileSetWindowCaptionColorAttribute(
+                DialogHandle,
+                IgnoreAccentColor);
+        }
+
+        return DialogHandle;
     }
 
     int K7ModernShowXamlWindow(


### PR DESCRIPTION
an undocumented usage from explorer and notepad.

```
COLORREF pvAttribute = static_cast<COLORREF>(DWMWA_COLOR_NONE);
::DwmSetWindowAttribute(hWnd, DWMWA_CAPTION_COLOR, &pvAttribute, sizeof(pvAttribute));
```

<img width="695" height="549" alt="Screenshot 2026-07-23 000934" src="https://github.com/user-attachments/assets/02927587-b99b-4948-85eb-db749594d3ce" />
