### PR TITLE
Add an Extract all button to the copy dialog

### DIFF
--- a/NanaZip.Modern/CopyLocationPage.cpp
+++ b/NanaZip.Modern/CopyLocationPage.cpp
@@ -8,6 +8,11 @@
 
 #include <string>
 
+namespace winrt
+{
+    using Windows::UI::Xaml::Visibility;
+}
+
 namespace winrt::NanaZip::Modern::implementation
 {
     CopyLocationPage::CopyLocationPage(
@@ -15,12 +20,14 @@ namespace winrt::NanaZip::Modern::implementation
         _In_opt_ LPCWSTR Title,
         _In_opt_ LPCWSTR Subtitle,
         _In_opt_ LPCWSTR AdditionalInformation,
-        _In_opt_ LPCWSTR InitialPath):
+        _In_opt_ LPCWSTR InitialPath,
+        _In_ BOOL ShowExtractAll):
         m_WindowHandle(WindowHandle),
         m_Title(Title),
         m_Subtitle(Subtitle),
         m_AdditionalInformation(AdditionalInformation),
-        m_InitialPath(InitialPath)
+        m_InitialPath(InitialPath),
+        m_ShowExtractAll(ShowExtractAll)
     {
     }
 
@@ -33,11 +40,28 @@ namespace winrt::NanaZip::Modern::implementation
         this->AdditionalInformationTextBlock().Text(
             this->m_AdditionalInformation);
         this->PathTextBox().Text(this->m_InitialPath);
+        this->ExtractAllButton().Visibility(winrt::Visibility::Visible);
     }
 
     LPCWSTR CopyLocationPage::GetPath()
     {
         return this->PathTextBox().Text().c_str();
+    }
+
+    void CopyLocationPage::ExtractAllButtonClick(
+        IInspectable const& sender,
+        RoutedEventArgs const& e)
+    {
+        UNREFERENCED_PARAMETER(sender);
+        UNREFERENCED_PARAMETER(e);
+
+        ::SendMessageW(
+            this->m_WindowHandle,
+            WM_COMMAND,
+            MAKEWPARAM(K7_COPY_LOCATION_DIALOG_RESULT_EXTRACT_ALL, BN_CLICKED),
+            0);
+
+        ::PostMessageW(this->m_WindowHandle, WM_CLOSE, 0, 0);
     }
 
     void CopyLocationPage::OkButtonClick(

--- a/NanaZip.Modern/CopyLocationPage.h
+++ b/NanaZip.Modern/CopyLocationPage.h
@@ -19,12 +19,17 @@ namespace winrt::NanaZip::Modern::implementation
             _In_opt_ LPCWSTR Title = nullptr,
             _In_opt_ LPCWSTR Subtitle = nullptr,
             _In_opt_ LPCWSTR AdditionalInformation = nullptr,
-            _In_opt_ LPCWSTR InitialPath = nullptr
+            _In_opt_ LPCWSTR InitialPath = nullptr,
+            _In_ BOOL ShowExtractAll = FALSE
         );
 
         void InitializeComponent();
 
         LPCWSTR GetPath();
+
+        void ExtractAllButtonClick(
+            IInspectable const& sender,
+            RoutedEventArgs const& e);
 
         void OkButtonClick(
             IInspectable const& sender,
@@ -45,6 +50,7 @@ namespace winrt::NanaZip::Modern::implementation
         LPCWSTR m_Subtitle = nullptr;
         LPCWSTR m_AdditionalInformation = nullptr;
         LPCWSTR m_InitialPath = nullptr;
+        BOOL m_ShowExtractAll = FALSE;
         std::wstring m_FinalPath;
     };
 }

--- a/NanaZip.Modern/CopyLocationPage.xaml
+++ b/NanaZip.Modern/CopyLocationPage.xaml
@@ -61,12 +61,26 @@
       Background="#37C9C9C9"
       BorderBrush="{ThemeResource CardStrokeColorDefault}"
       BorderThickness="0,1,0,0">
-      <StackPanel
+      <Grid
         Grid.Column="1"
-        Padding="0,0,12,0"
-        HorizontalAlignment="Right"
-        Orientation="Horizontal">
+        Padding="12,0,12,0">
+        <Grid.ColumnDefinitions>
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="*" />
+          <ColumnDefinition Width="Auto" />
+          <ColumnDefinition Width="Auto" />
+        </Grid.ColumnDefinitions>
+
         <Button
+          x:Name="ExtractAllButton"
+          x:Uid="/NanaZip.Modern/CopyLocationPage/ExtractAllButton"
+          Width="120"
+          Margin="4,16,0,16"
+          Click="ExtractAllButtonClick"
+          Content="[Extract all...]" />
+
+        <Button
+          Grid.Column="2"
           x:Name="PauseButton"
           x:Uid="/NanaZip.Modern/Common/OKButton"
           Width="120"
@@ -74,12 +88,13 @@
           Click="OkButtonClick"
           Content="[OK]" />
         <Button
+          Grid.Column="3"
           x:Uid="/NanaZip.Modern/Common/CancelButton"
           Width="120"
           Margin="4,16,4,16"
           Click="CancelButtonClick"
           Content="[Cancel]" />
-      </StackPanel>
+      </Grid>
     </Grid>
   </Grid>
 </Page>

--- a/NanaZip.Modern/NanaZip.Modern.cpp
+++ b/NanaZip.Modern/NanaZip.Modern.cpp
@@ -571,6 +571,7 @@ EXTERN_C INT WINAPI K7ModernShowCopyLocationDialog(
     _In_opt_ LPCWSTR Subtitle,
     _In_opt_ LPCWSTR AdditionalInformation,
     _In_opt_ LPCWSTR InitialPath,
+    _In_ BOOL ShowExtractAll,
     _In_ SUBCLASSPROC WindowSubclassHandler,
     _In_ LPVOID WindowSubclassContext)
 {
@@ -590,7 +591,8 @@ EXTERN_C INT WINAPI K7ModernShowCopyLocationDialog(
         Title,
         Subtitle,
         AdditionalInformation,
-        InitialPath);
+        InitialPath,
+        ShowExtractAll);
 
     if (WindowSubclassHandler)
     {

--- a/NanaZip.Modern/NanaZip.Modern.h
+++ b/NanaZip.Modern/NanaZip.Modern.h
@@ -219,6 +219,7 @@ EXTERN_C INT WINAPI K7ModernShowProgressWindow(
  *        the copy location dialog when the "OK" button is clicked.
  */
 #define K7_COPY_LOCATION_DIALOG_RESULT_OK 1
+#define K7_COPY_LOCATION_DIALOG_RESULT_EXTRACT_ALL 2
 
 /**
  * @brief Show the copy location dialog window.
@@ -246,6 +247,7 @@ EXTERN_C INT WINAPI K7ModernShowCopyLocationDialog(
     _In_opt_ LPCWSTR Subtitle,
     _In_opt_ LPCWSTR AdditionalInformation,
     _In_opt_ LPCWSTR InitialPath,
+    _In_ BOOL ShowExtractAll,
     _In_ SUBCLASSPROC WindowSubclassHandler,
     _In_ LPVOID WindowSubclassContext);
 

--- a/NanaZip.Modern/Strings/af/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/af/CopyLocationPage.resw
@@ -39,4 +39,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Alles uitpak...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ar/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ar/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>تحديد مجلد الوجهة</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>استخراج الكل...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/az-arab/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/az-arab/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Qovluğu göstərin.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Hamısını çıxarın...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/be/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/be/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Пакажыце папку.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Распакуйце ўсё...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/bg/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/bg/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Избор на целева директория.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Извличане на всичко...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/bn/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/bn/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>গন্তব্য ফোল্ডার নির্বাচন.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>সবকিছু এক্সট্র্যাক্ট করুন...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ca-es-valencia/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ca-es-valencia/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Seleccioneu carpeta de destinació.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Extrau-ho tot...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ca/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ca/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Seleccioneu la carpeta de destinació:</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Extreu-ho tot...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/cs/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/cs/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Vyberte cílovou složku.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Extrahovat vše...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/cy/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/cy/CopyLocationPage.resw
@@ -39,4 +39,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Echdynnu popeth...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/da/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/da/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Vælg destinationsmappen.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Udpak alle...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/de/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/de/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Zielordner auswählen</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Alle extrahieren...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/el/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/el/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Επιλέξτε φάκελο προορισμού.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Εξαγωγή όλων...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/en/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/en/CopyLocationPage.resw
@@ -45,4 +45,7 @@
   <data name="ExtractAllButton.Content" xml:space="preserve">
     <value>Extract all...</value>
   </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>120</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/en/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/en/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Select destination folder.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Extract all...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/eo/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/eo/CopyLocationPage.resw
@@ -39,4 +39,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Elpaki ĉion...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/es/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/es/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Selecciona la carpeta de destino</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Extraer todo...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/et/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/et/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Valige sihtkaust.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Paki kõik lahti...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/eu/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/eu/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Hautatu helmuga agiritegia.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Erau guztiak...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/fa/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/fa/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>پوشه مقصد را انتخاب كنيد</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>همه را استخراج کنید...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/fi/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/fi/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Valitse kohdekansio.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Pura kaikki...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/fr/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/fr/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Sélectionnez le dossier de destination.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Tout extraire...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/fy/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/fy/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Bestimmingsmap selektearje.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Alles útpakke...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ga/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ga/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Roghnaigh an spriocfhillteán.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Bain gach rud amach...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/gl/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/gl/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Seleccione cartafol destino.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Extraer todo...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/gu/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/gu/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>ગન્તવ્ય ફોલ્ડર ચયનિત કરો.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>બધું એક્સટ્રેક્ટ કરો...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/he/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/he/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>.בחר תיקיית יעד</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>חלץ הכל...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/hi/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/hi/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>गन्तव्य फोल्डर चयनित करें.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>सभी निकालें...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/hr/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/hr/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Odabir odredišne mape.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Izdvoji sve...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/hu/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/hu/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Válassza ki a cél mappát.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Összes kibontása...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/hy/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/hy/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Ընտրել թղթապանակ</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Հանել բոլորը...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/id/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/id/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Pilih direktori tujuan.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Ekstrak semua...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/is/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/is/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Veldu móttökumöppu.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Afþjappa öllu...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/it/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/it/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Selezionare la cartella di destinazione.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Estrai tutto...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ja/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ja/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>対象のフォルダーを選択してください。</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>すべて展開...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ka/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ka/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>აირჩიეთ დანიშნულების საქაღალდე.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>ყველას ამოღება...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/kk/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/kk/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Қалтаны нұсқаңыз</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Барлығын шығару...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ko/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ko/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>대상 폴더를 선택하세요.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>모두 압축 풀기...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ku-arab/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ku-arab/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>بوخچەی مەبەست دیاری بکە.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>هەمووی دەربهێنە...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ky-kg/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ky-kg/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Баштыкты көрсөтүңүз.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Баарын чыгаруу...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/lt/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/lt/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Pasirinkite paskirties aplanką.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Išskleisti viską...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/lv/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/lv/CopyLocationPage.resw
@@ -39,4 +39,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Izvilkt visu...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/mk/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/mk/CopyLocationPage.resw
@@ -39,4 +39,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Извади ги сите...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/mn-cyrl/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/mn-cyrl/CopyLocationPage.resw
@@ -39,4 +39,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Бүгдийг задлах...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/mn-mong/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/mn-mong/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>ᠬᠠᠪᠲᠠᠰᠤ ᠰᠣᠩᠭᠣᠬᠤ</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>ᠪᠦᠬᠦᠨ ᠵᠠᠳᠠᠯᠬᠤ...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/mr/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/mr/CopyLocationPage.resw
@@ -39,4 +39,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>सर्व काढा...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ms/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ms/CopyLocationPage.resw
@@ -39,4 +39,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Ekstrak semua...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/nb/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/nb/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Velg målmappe.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Pakk ut alt...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ne/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ne/CopyLocationPage.resw
@@ -39,4 +39,10 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>सबै निकाल्नुहोस्...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/nl/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/nl/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Selecteer een doelmap.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Alles uitpakken...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/nn/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/nn/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Vel målmappe.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Pakk ut alt...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/pa-in/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/pa-in/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>ਨਿਯਤ ਫੋਲਡਰ ਚੁਣੋ</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>ਸਭ ਨੂੰ ਐਕਸਟ੍ਰੈਕਟ ਕਰੋ...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/pl/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/pl/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Wybierz folder docelowy.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Wypakuj wszystko...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ps/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ps/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>.موخه پوښۍ وټاکئ</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>ټول استخراج کړئ...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/pt-BR/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/pt-BR/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Selecionar a pasta destino.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Extrair tudo...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/pt/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/pt/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Seleccione a pasta de destino.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Extrair tudo...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ro/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ro/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Alege directorul destinaţie.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Extrage tot...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ru/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ru/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Укажите папку.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Извлечь всё...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/si/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/si/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>ගමනාන්ත බහාලුම තෝරන්න.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>සියල්ල උපුටා ගන්න...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/sk/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/sk/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Vyberte cieľový priečinok.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Extrahovať všetko...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/sl/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/sl/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Izberite ciljno mapo.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Ekstrahiraj vse...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/sq/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/sq/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Zgjidh dosjen e vendarritjes.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Nxirr të gjitha...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/sr-Latn/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/sr-Latn/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Izaberite odredišnu fasciklu.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Izdvoji sve...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/sr-cyrl/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/sr-cyrl/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Изаберите одредишну фасциклу.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Издвој све...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/sv/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/sv/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Välj målmapp.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Extrahera alla...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/sw/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/sw/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Teua folda fikio.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Toa zote...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ta/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ta/CopyLocationPage.resw
@@ -39,4 +39,7 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=2.0.3500.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>பிரித்தெடு...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/tg-arab/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/tg-arab/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Ҷузвдонеро муайян кардан.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Ҳамаро баровардан...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/th/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/th/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>เลือกโฟลเดอร์ที่ตั้ง</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>แตกไฟล์ทั้งหมด...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/tk-cyrl/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/tk-cyrl/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Bukja seçiň.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Ählisini çykarmak...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/tr/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/tr/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Hedef klasörü seçin.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Tümünü ayıkla...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/tt-arab/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/tt-arab/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Папканы күрсәтегез.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Барысын да чыгару...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/ug-arab/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/ug-arab/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>نىشان قىسقۇچ تاللاڭ</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>ھەممىنى چىقىرىش...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/uk/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/uk/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Виберіть папку призначення.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Розпакувати все...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/uz-cyrl/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/uz-cyrl/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Белгиланган жилдни танланг.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Барчасини чиқариш...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/uz-latn/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/uz-latn/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Belgilangan jildni tanlang.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Barchasini chiqarish...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/vi/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/vi/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Chọn thư mục đến.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Giải nén tất cả...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/yo-latn/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/yo-latn/CopyLocationPage.resw
@@ -42,4 +42,10 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>Ṣàyàn èbúté àpò faíli.</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>Yọ gbogbo rẹ̀ jáde...</value>
+  </data>
+  <data name="ExtractAllButton.Width" type="System.Double" xml:space="preserve">
+    <value>200</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/zh-Hans/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/zh-Hans/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>选择目标文件夹。</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>全部解压缩...</value>
+  </data>
 </root>

--- a/NanaZip.Modern/Strings/zh-Hant/CopyLocationPage.resw
+++ b/NanaZip.Modern/Strings/zh-Hant/CopyLocationPage.resw
@@ -42,4 +42,7 @@
   <data name="SelectDestinationText" xml:space="preserve">
     <value>選擇目標資料夾。</value>
   </data>
+  <data name="ExtractAllButton.Content" xml:space="preserve">
+    <value>全部解壓縮...</value>
+  </data>
 </root>

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/App.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/App.cpp
@@ -68,6 +68,13 @@ void CPanelCallbackImp::SetFocusToPath(unsigned index)
 
 
 void CPanelCallbackImp::OnCopy(bool move, bool copyToSame) { _app->OnCopy(move, copyToSame, _index); }
+// **************** NanaZip Modification Start ****************
+bool CPanelCallbackImp::OnCopyOrExtract() {
+    bool wantExtractAll = false;
+    this->_app->OnCopy(false, false, this->_index, true, &wantExtractAll);
+    return !wantExtractAll;
+}
+// **************** NanaZip Modification End ****************
 void CPanelCallbackImp::OnSetSameFolder() { _app->OnSetSameFolder(_index); }
 void CPanelCallbackImp::OnSetSubFolder()  { _app->OnSetSubFolder(_index); }
 void CPanelCallbackImp::PanelWasFocused() { _app->SetFocusedPanel(_index); _app->RefreshTitlePanel(_index); }
@@ -499,7 +506,15 @@ static bool IsFsPath(const FString &path)
 }
 */
 
-void CApp::OnCopy(bool move, bool copyToSame, int srcPanelIndex)
+// **************** NanaZip Modification Start ****************
+//void CApp::OnCopy(bool move, bool copyToSame, int srcPanelIndex)
+void CApp::OnCopy(
+    bool move,
+    bool copyToSame,
+    int srcPanelIndex,
+    bool showExtractAll,
+    bool *wantExtractAll)
+// **************** NanaZip Modification End ****************
 {
   unsigned destPanelIndex = (NumPanels <= 1) ? srcPanelIndex : (1 - srcPanelIndex);
   CPanel &srcPanel = Panels[srcPanelIndex];
@@ -554,14 +569,31 @@ void CApp::OnCopy(bool move, bool copyToSame, int srcPanelIndex)
   {
     CCopyDialog copyDialog;
 
+    // **************** NanaZip Modification Start ****************
+    if (showExtractAll)
+    {
+        copyDialog.m_ShowExtractAll = true;
+    }
+    // **************** NanaZip Modification End ****************
     copyDialog.Strings = copyFolders;
     copyDialog.Value = destPath;
     LangString(move ? IDS_MOVE : IDS_COPY, copyDialog.Title);
     LangString(move ? IDS_MOVE_TO : IDS_COPY_TO, copyDialog.Static);
     copyDialog.Info = srcPanel.GetItemsInfoString(indices);
 
-    if (copyDialog.Create(srcPanel.GetParent()) != IDOK)
-      return;
+    // **************** NanaZip Modification Start ****************
+    // if (copyDialog.Create(srcPanel.GetParent()) != IDOK)
+    // return;
+    INT_PTR result = copyDialog.Create(srcPanel.GetParent());
+    if (result != IDOK)
+    {
+        if (wantExtractAll)
+        {
+            *wantExtractAll = result == IDRETRY;
+        }
+        return;
+    }
+    // **************** NanaZip Modification End ****************
 
     destPath = copyDialog.Value;
   }

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/App.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/App.h
@@ -43,6 +43,9 @@ public:
   virtual void OnTab();
   virtual void SetFocusToPath(unsigned index);
   virtual void OnCopy(bool move, bool copyToSame);
+  // **************** NanaZip Modification Start ****************
+  virtual bool OnCopyOrExtract();
+  // **************** NanaZip Modification End ****************
   virtual void OnSetSameFolder();
   virtual void OnSetSubFolder();
   virtual void PanelWasFocused();
@@ -137,7 +140,7 @@ public:
   CMyComPtr<IDropTarget> _dropTarget;
 
   UString LangString_N_SELECTED_ITEMS;
-  
+
   void ReloadLang();
 
   CApp(): _window(0), NumPanels(2), LastFocusedPanel(0),
@@ -171,8 +174,16 @@ public:
     _dropTargetSpec->SrcPanelIndex = -1;
   }
 
-  
-  void OnCopy(bool move, bool copyToSame, int srcPanelIndex);
+
+  // **************** NanaZip Modification Start ****************
+  //void OnCopy(bool move, bool copyToSame, int srcPanelIndex);
+  void OnCopy(
+    bool move,
+    bool copyToSame,
+    int srcPanelIndex,
+    bool showExtractAll = false,
+    bool *wantExtractAll = nullptr);
+  // **************** NanaZip Modification End ****************
   void OnSetSameFolder(int srcPanelIndex);
   void OnSetSubFolder(int srcPanelIndex);
 
@@ -202,14 +213,14 @@ public:
 
   void DiffFiles(const UString &path1, const UString &path2);
   void DiffFiles();
-  
+
   void VerCtrl(unsigned id);
 
   void Split();
   void Combine();
   void Properties() { GetFocusedPanel().Properties(); }
   void Comment() { GetFocusedPanel().ChangeComment(); }
-  
+
   #ifndef UNDER_CE
   void Link();
   void OpenAltStreams() { GetFocusedPanel().OpenAltStreams(); }
@@ -266,7 +277,7 @@ public:
 
   void SetListSettings();
   HRESULT SwitchOnOffOnePanel();
-  
+
   CIntVector _timestampLevels;
 
   bool GetFlatMode() { return Panels[LastFocusedPanel].GetFlatMode(); }
@@ -285,7 +296,7 @@ public:
   }
 
   // bool Get_ShowNtfsStrems_Mode() { return Panels[LastFocusedPanel].Get_ShowNtfsStrems_Mode(); }
-  
+
   void ChangeFlatMode() { Panels[LastFocusedPanel].ChangeFlatMode(); }
   // void Change_ShowNtfsStrems_Mode() { Panels[LastFocusedPanel].Change_ShowNtfsStrems_Mode(); }
   // void Change_ShowDeleted() { ShowDeletedFiles = !ShowDeletedFiles; }

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/CopyDialog.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/CopyDialog.cpp
@@ -28,6 +28,7 @@ INT_PTR CCopyDialog::Create(HWND parentWindow)
         this->Static.Ptr(),
         this->Info.Ptr(),
         this->Value.Ptr(),
+        this->m_ShowExtractAll ? TRUE : FALSE,
         &CCopyDialog::ModernWindowHandler,
         this);
 
@@ -49,6 +50,9 @@ bool CCopyDialog::ModernMessageRouter(UINT uMsg, WPARAM wParam, LPARAM lParam)
             case K7_COPY_LOCATION_DIALOG_RESULT_OK:
                 this->ModernOK();
                 return true;
+            case K7_COPY_LOCATION_DIALOG_RESULT_EXTRACT_ALL:
+                this->ModernExtractAll();
+                return true;
             }
         }
     }
@@ -61,6 +65,11 @@ void CCopyDialog::ModernOK()
     Value = ::K7ModernGetCopyLocationDialogPath(
         m_WindowHandle);
     m_ReturnCode = IDOK;
+}
+
+void CCopyDialog::ModernExtractAll()
+{
+    m_ReturnCode = IDRETRY;
 }
 
 LRESULT CALLBACK CCopyDialog::ModernWindowHandler(

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/CopyDialog.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/CopyDialog.h
@@ -24,6 +24,7 @@ class CCopyDialog: public NWindows::NControl::CModalDialog
   bool ModernMessageRouter(UINT uMsg, WPARAM wParam, LPARAM lParam);
 
   void ModernOK();
+  void ModernExtractAll();
 
 #if 0 // ******** Annotated 7-Zip Mainline Source Code snippet Start ********
   NWindows::NControl::CComboBox _path;
@@ -44,6 +45,7 @@ public:
   HWND m_WindowHandle = nullptr;
   bool m_FirstRun = false;
   int m_ReturnCode = IDCLOSE;
+  bool m_ShowExtractAll = false;
 // **************** NanaZip Modification End ****************
 
 // **************** NanaZip Modification Start ****************

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.cpp
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.cpp
@@ -1280,7 +1280,10 @@ void CPanel::ExtractArchives()
 {
   if (_parentFolders.Size() > 0)
   {
-    ExtractFromArchive();
+    // **************** NanaZip Modification Start ****************
+    // _panelCallback->OnCopy(false, false);
+    CopyFromArchive();
+    // **************** NanaZip Modification End ****************
     return;
   }
   CRecordVector<UInt32> indices;
@@ -1307,40 +1310,52 @@ void CPanel::ExtractArchives()
       );
 }
 
-void CPanel::ExtractFromArchive()
+// **************** NanaZip Modification Start ****************
+void CPanel::CopyFromArchive()
 {
-  if (_parentFolders.Size() > 1) {
-    _panelCallback->OnCopy(false, false);
-    return;
-  }
+    UString archivePath = this->_parentFolders[0].VirtualPath;
+    bool wantsExtractAll = true;
 
-  CRecordVector<UInt32> indices;
-  GetOperatedItemIndices(indices);
-  if (indices.Size() > 0) {
-    _panelCallback->OnCopy(false, false);
-    return;
-  }
+    if (this->_parentFolders.Size() > 1)
+    {
+        wantsExtractAll = false;
+    }
 
-  UString path = GetFsPath();
-  if (IsPathSepar(path.Back()))
-      path.DeleteBack();
-  if (path != _parentFolders[0].VirtualPath) {
-    _panelCallback->OnCopy(false, false);
-    return;
-  }
-  UStringVector paths;
-  paths.Add(path);
-  UString outFolder = GetSubFolderNameForExtract2(path);
+    CRecordVector<UInt32> indices;
+    this->GetOperatedItemIndices(indices);
+    if (indices.Size() > 0)
+    {
+        wantsExtractAll = false;
+    }
 
-  CContextMenuInfo ci;
-  ci.Load();
+    UString path = this->GetFsPath();
+    if (::IsPathSepar(path.Back()))
+    {
+        path.DeleteBack();
+    }
+    if (path != archivePath)
+    {
+        wantsExtractAll = false;
+    }
 
-  ::ExtractArchives(paths, outFolder
-      , true // showDialog
-      , false // elimDup
-      , ci.WriteZone
-      );
+    if (wantsExtractAll || !this->_panelCallback->OnCopyOrExtract())
+    {
+        UStringVector paths;
+        paths.Add(archivePath);
+        UString outFolder = ::GetSubFolderNameForExtract2(archivePath);
+
+        CContextMenuInfo ci;
+        ci.Load();
+
+        ::ExtractArchives(
+            paths,
+            outFolder,
+            true, // showDialog
+            false, // elimDup
+            ci.WriteZone);
+    }
 }
+// **************** NanaZip Modification End ****************
 
 /*
 static void AddValuePair(UINT resourceID, UInt64 value, UString &s)

--- a/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.h
+++ b/NanaZip.UI.Modern/SevenZip/CPP/7zip/UI/FileManager/Panel.h
@@ -66,6 +66,10 @@ struct CPanelCallback
   virtual void OnTab() = 0;
   virtual void SetFocusToPath(unsigned index) = 0;
   virtual void OnCopy(bool move, bool copyToSame) = 0;
+  // **************** NanaZip Modification Start ****************
+  // Returns true if copy was selected, or false if Extract All was selected.
+  virtual bool OnCopyOrExtract() = 0;
+  // **************** NanaZip Modification End ****************
   virtual void OnSetSameFolder() = 0;
   virtual void OnSetSubFolder() = 0;
   virtual void PanelWasFocused() = 0;
@@ -893,7 +897,10 @@ public:
 
   void GetFilePaths(const CRecordVector<UInt32> &indices, UStringVector &paths, bool allowFolders = false);
   void ExtractArchives();
-  void ExtractFromArchive();
+  // **************** NanaZip Modification Start ****************
+  void CopyFromArchive();
+  void ExtractFromArchive(const UString &archivePath);
+  // **************** NanaZip Modification End ****************
   void TestArchives();
 
   // **************** NanaZip Modification Start ****************


### PR DESCRIPTION
The behavior of the panel regarding when to show the copy to/extract dialogs is not obvious. So an Extract all button here is a convenient shortcut.

Note, only ‎NanaZip.UI.Modern was changed.

<!---
  Read https://github.com/M2Team/NanaZip/blob/main/CONTRIBUTING.md word by word
  first. For security fix PRs, also need to read
  https://github.com/M2Team/NanaZip/blob/main/Security.md.
-->
