### PR TITLE
Fix UTF-8 passwords for WinZip AES extraction

### DIFF
--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
@@ -991,6 +991,10 @@ HRESULT CZipDecoder::Decode(
   bool needCRC = true;
   bool wzAesMode = false;
   bool pkAesMode = false;
+  // **************** NanaZip Modification Start ****************
+  AString_Wipe wzAesUtf8Password;
+  bool wzAesUtf8PasswordIsDefined = false;
+  // **************** NanaZip Modification End ****************
 
   bool badDescriptor = item.IsBadDescriptor();
   if (badDescriptor)
@@ -1114,6 +1118,14 @@ HRESULT CZipDecoder::Decode(
         {
           UnicodeStringToMultiByte2(charPassword, (LPCOLESTR)password, CP_ACP);
         }
+        // **************** NanaZip Modification Start ****************
+        if (wzAesMode)
+        {
+          ConvertUnicodeToUTF8((LPCOLESTR)password, wzAesUtf8Password);
+          wzAesUtf8PasswordIsDefined =
+              (wzAesUtf8Password != charPassword);
+        }
+        // **************** NanaZip Modification End ****************
         /*
         if (wzAesMode || pkAesMode)
         {
@@ -1272,7 +1284,25 @@ HRESULT CZipDecoder::Decode(
         result = _wzAesDecoder->ReadHeader(inStream);
         if (result == S_OK)
         {
+#if 0 // ******** Annotated 7-Zip Mainline Source Code snippet Start ********
           if (!_wzAesDecoder->Init_and_CheckPassword())
+#endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
+          // **************** NanaZip Modification Start ****************
+          bool passwordIsCorrect =
+              _wzAesDecoder->Init_and_CheckPassword();
+          if (!passwordIsCorrect && wzAesUtf8PasswordIsDefined)
+          {
+            if (_wzAesDecoder->CryptoSetPassword(
+                (const Byte *)(const char *)wzAesUtf8Password,
+                wzAesUtf8Password.Len()) == S_OK)
+            {
+              passwordIsCorrect =
+                  _wzAesDecoder->Init_and_CheckPassword();
+            }
+          }
+          wzAesUtf8Password.Wipe_and_Empty();
+          if (!passwordIsCorrect)
+          // **************** NanaZip Modification End ****************
           {
             res = NExtract::NOperationResult::kWrongPassword;
             return S_OK;

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
@@ -1315,6 +1315,10 @@ HRESULT CZipDecoder::Decode(
           // **************** NanaZip Modification Start ****************
 #if 0 // ******** Annotated 7-Zip Mainline Source Code snippet Start ********
           if (!_wzAesDecoder->Init_and_CheckPassword())
+          {
+            res = NExtract::NOperationResult::kWrongPassword;
+            return S_OK;
+          }
 #endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
           bool IsPasswordCorrect = false;
           if (S_OK == this->_wzAesDecoder->CryptoSetPassword(
@@ -1337,6 +1341,10 @@ HRESULT CZipDecoder::Decode(
           WzAesUtf8Password.Wipe_and_Empty();
           WzAesDefaultEncodingPassword.Wipe_and_Empty();
           if (!IsPasswordCorrect)
+          {
+            res = NExtract::NOperationResult::kWrongPassword;
+            return S_OK;
+          }
           // **************** NanaZip Modification End ****************
           {
             res = NExtract::NOperationResult::kWrongPassword;

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
@@ -1123,8 +1123,6 @@ HRESULT CZipDecoder::Decode(
 #endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
         if (wzAesMode)
         {
-          // WzAES has no password encoding metadata, so use UTF-8 by default
-          // and preserve CP_ACP as a read-only compatibility fallback.
           ConvertUnicodeToUTF8((LPCOLESTR)password, wzAesUtf8Password);
           UnicodeStringToMultiByte2(
               wzAesCodePagePassword, (LPCOLESTR)password, CP_ACP);

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
@@ -993,7 +993,7 @@ HRESULT CZipDecoder::Decode(
   bool pkAesMode = false;
   // **************** NanaZip Modification Start ****************
   AString_Wipe WzAesUtf8Password;
-  AString_Wipe WzAesCodePagePassword;
+  AString_Wipe WzAesDefaultEncodingPassword;
   // **************** NanaZip Modification End ****************
 
   bool badDescriptor = item.IsBadDescriptor();
@@ -1127,7 +1127,7 @@ HRESULT CZipDecoder::Decode(
               static_cast<LPCOLESTR>(password),
               WzAesUtf8Password);
           ::UnicodeStringToMultiByte2(
-              WzAesCodePagePassword,
+              WzAesDefaultEncodingPassword,
               static_cast<LPCOLESTR>(password),
               CP_ACP);
         }
@@ -1324,17 +1324,18 @@ HRESULT CZipDecoder::Decode(
             IsPasswordCorrect = this->_wzAesDecoder->Init_and_CheckPassword();
           }
           if (!IsPasswordCorrect &&
-              WzAesCodePagePassword != WzAesUtf8Password)
+              WzAesDefaultEncodingPassword != WzAesUtf8Password)
           {
             if (S_OK == this->_wzAesDecoder->CryptoSetPassword(
-                reinterpret_cast<const Byte *>(WzAesCodePagePassword.Ptr()),
-                WzAesCodePagePassword.Len()))
+                reinterpret_cast<const Byte *>(
+                    WzAesDefaultEncodingPassword.Ptr()),
+                WzAesDefaultEncodingPassword.Len()))
             {
               IsPasswordCorrect = this->_wzAesDecoder->Init_and_CheckPassword();
             }
           }
           WzAesUtf8Password.Wipe_and_Empty();
-          WzAesCodePagePassword.Wipe_and_Empty();
+          WzAesDefaultEncodingPassword.Wipe_and_Empty();
           if (!IsPasswordCorrect)
           // **************** NanaZip Modification End ****************
           {

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
@@ -993,7 +993,7 @@ HRESULT CZipDecoder::Decode(
   bool pkAesMode = false;
   // **************** NanaZip Modification Start ****************
   AString_Wipe wzAesUtf8Password;
-  bool wzAesUtf8PasswordIsDefined = false;
+  AString_Wipe wzAesCodePagePassword;
   // **************** NanaZip Modification End ****************
 
   bool badDescriptor = item.IsBadDescriptor();
@@ -1115,15 +1115,24 @@ HRESULT CZipDecoder::Decode(
         }
         else
 #endif
+        // **************** NanaZip Modification Start ****************
+#if 0 // ******** Annotated 7-Zip Mainline Source Code snippet Start ********
         {
           UnicodeStringToMultiByte2(charPassword, (LPCOLESTR)password, CP_ACP);
         }
-        // **************** NanaZip Modification Start ****************
+#endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
         if (wzAesMode)
         {
+          // WzAES has no password encoding metadata, so use UTF-8 by default
+          // and preserve CP_ACP as a read-only compatibility fallback.
           ConvertUnicodeToUTF8((LPCOLESTR)password, wzAesUtf8Password);
-          wzAesUtf8PasswordIsDefined =
-              (wzAesUtf8Password != charPassword);
+          UnicodeStringToMultiByte2(
+              wzAesCodePagePassword, (LPCOLESTR)password, CP_ACP);
+        }
+        else
+        {
+          UnicodeStringToMultiByte2(
+              charPassword, (LPCOLESTR)password, CP_ACP);
         }
         // **************** NanaZip Modification End ****************
         /*
@@ -1141,6 +1150,8 @@ HRESULT CZipDecoder::Decode(
         }
         */
       }
+      // **************** NanaZip Modification Start ****************
+#if 0 // ******** Annotated 7-Zip Mainline Source Code snippet Start ********
       HRESULT result = cryptoSetPassword->CryptoSetPassword(
         (const Byte *)(const char *)charPassword, charPassword.Len());
       if (result != S_OK)
@@ -1148,6 +1159,18 @@ HRESULT CZipDecoder::Decode(
         res = NExtract::NOperationResult::kWrongPassword;
         return S_OK;
       }
+#endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
+      if (!wzAesMode)
+      {
+        HRESULT result = cryptoSetPassword->CryptoSetPassword(
+          (const Byte *)(const char *)charPassword, charPassword.Len());
+        if (result != S_OK)
+        {
+          res = NExtract::NOperationResult::kWrongPassword;
+          return S_OK;
+        }
+      }
+      // **************** NanaZip Modification End ****************
     }
     else
     {
@@ -1288,19 +1311,27 @@ HRESULT CZipDecoder::Decode(
 #if 0 // ******** Annotated 7-Zip Mainline Source Code snippet Start ********
           if (!_wzAesDecoder->Init_and_CheckPassword())
 #endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
-          bool passwordIsCorrect =
-              _wzAesDecoder->Init_and_CheckPassword();
-          if (!passwordIsCorrect && wzAesUtf8PasswordIsDefined)
+          bool passwordIsCorrect = false;
+          if (_wzAesDecoder->CryptoSetPassword(
+              (const Byte *)(const char *)wzAesUtf8Password,
+              wzAesUtf8Password.Len()) == S_OK)
+          {
+            passwordIsCorrect =
+                _wzAesDecoder->Init_and_CheckPassword();
+          }
+          if (!passwordIsCorrect &&
+              wzAesCodePagePassword != wzAesUtf8Password)
           {
             if (_wzAesDecoder->CryptoSetPassword(
-                (const Byte *)(const char *)wzAesUtf8Password,
-                wzAesUtf8Password.Len()) == S_OK)
+                (const Byte *)(const char *)wzAesCodePagePassword,
+                wzAesCodePagePassword.Len()) == S_OK)
             {
               passwordIsCorrect =
                   _wzAesDecoder->Init_and_CheckPassword();
             }
           }
           wzAesUtf8Password.Wipe_and_Empty();
+          wzAesCodePagePassword.Wipe_and_Empty();
           if (!passwordIsCorrect)
           // **************** NanaZip Modification End ****************
           {

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
@@ -1284,10 +1284,10 @@ HRESULT CZipDecoder::Decode(
         result = _wzAesDecoder->ReadHeader(inStream);
         if (result == S_OK)
         {
+          // **************** NanaZip Modification Start ****************
 #if 0 // ******** Annotated 7-Zip Mainline Source Code snippet Start ********
           if (!_wzAesDecoder->Init_and_CheckPassword())
 #endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
-          // **************** NanaZip Modification Start ****************
           bool passwordIsCorrect =
               _wzAesDecoder->Init_and_CheckPassword();
           if (!passwordIsCorrect && wzAesUtf8PasswordIsDefined)

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
@@ -1123,17 +1123,19 @@ HRESULT CZipDecoder::Decode(
 #endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
         if (wzAesMode)
         {
-          ::ConvertUnicodeToUTF8((LPCOLESTR)password, WzAesUtf8Password);
+          ::ConvertUnicodeToUTF8(
+              static_cast<LPCOLESTR>(password),
+              WzAesUtf8Password);
           ::UnicodeStringToMultiByte2(
               WzAesCodePagePassword,
-              (LPCOLESTR)password,
+              static_cast<LPCOLESTR>(password),
               CP_ACP);
         }
         else
         {
           ::UnicodeStringToMultiByte2(
               charPassword,
-              (LPCOLESTR)password,
+              static_cast<LPCOLESTR>(password),
               CP_ACP);
         }
         // **************** NanaZip Modification End ****************
@@ -1165,9 +1167,9 @@ HRESULT CZipDecoder::Decode(
       if (!wzAesMode)
       {
         HRESULT Result = cryptoSetPassword->CryptoSetPassword(
-            (const Byte *)(const char *)charPassword,
+            reinterpret_cast<const Byte *>(charPassword.Ptr()),
             charPassword.Len());
-        if (Result != S_OK)
+        if (S_OK != Result)
         {
           res = NExtract::NOperationResult::kWrongPassword;
           return S_OK;
@@ -1315,22 +1317,20 @@ HRESULT CZipDecoder::Decode(
           if (!_wzAesDecoder->Init_and_CheckPassword())
 #endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
           bool IsPasswordCorrect = false;
-          if (this->_wzAesDecoder->CryptoSetPassword(
-              (const Byte *)(const char *)WzAesUtf8Password,
-              WzAesUtf8Password.Len()) == S_OK)
+          if (S_OK == this->_wzAesDecoder->CryptoSetPassword(
+              reinterpret_cast<const Byte *>(WzAesUtf8Password.Ptr()),
+              WzAesUtf8Password.Len()))
           {
-            IsPasswordCorrect =
-                this->_wzAesDecoder->Init_and_CheckPassword();
+            IsPasswordCorrect = this->_wzAesDecoder->Init_and_CheckPassword();
           }
           if (!IsPasswordCorrect &&
               WzAesCodePagePassword != WzAesUtf8Password)
           {
-            if (this->_wzAesDecoder->CryptoSetPassword(
-                (const Byte *)(const char *)WzAesCodePagePassword,
-                WzAesCodePagePassword.Len()) == S_OK)
+            if (S_OK == this->_wzAesDecoder->CryptoSetPassword(
+                reinterpret_cast<const Byte *>(WzAesCodePagePassword.Ptr()),
+                WzAesCodePagePassword.Len()))
             {
-              IsPasswordCorrect =
-                  this->_wzAesDecoder->Init_and_CheckPassword();
+              IsPasswordCorrect = this->_wzAesDecoder->Init_and_CheckPassword();
             }
           }
           WzAesUtf8Password.Wipe_and_Empty();

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandler.cpp
@@ -992,8 +992,8 @@ HRESULT CZipDecoder::Decode(
   bool wzAesMode = false;
   bool pkAesMode = false;
   // **************** NanaZip Modification Start ****************
-  AString_Wipe wzAesUtf8Password;
-  AString_Wipe wzAesCodePagePassword;
+  AString_Wipe WzAesUtf8Password;
+  AString_Wipe WzAesCodePagePassword;
   // **************** NanaZip Modification End ****************
 
   bool badDescriptor = item.IsBadDescriptor();
@@ -1123,14 +1123,18 @@ HRESULT CZipDecoder::Decode(
 #endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
         if (wzAesMode)
         {
-          ConvertUnicodeToUTF8((LPCOLESTR)password, wzAesUtf8Password);
-          UnicodeStringToMultiByte2(
-              wzAesCodePagePassword, (LPCOLESTR)password, CP_ACP);
+          ::ConvertUnicodeToUTF8((LPCOLESTR)password, WzAesUtf8Password);
+          ::UnicodeStringToMultiByte2(
+              WzAesCodePagePassword,
+              (LPCOLESTR)password,
+              CP_ACP);
         }
         else
         {
-          UnicodeStringToMultiByte2(
-              charPassword, (LPCOLESTR)password, CP_ACP);
+          ::UnicodeStringToMultiByte2(
+              charPassword,
+              (LPCOLESTR)password,
+              CP_ACP);
         }
         // **************** NanaZip Modification End ****************
         /*
@@ -1160,9 +1164,10 @@ HRESULT CZipDecoder::Decode(
 #endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
       if (!wzAesMode)
       {
-        HRESULT result = cryptoSetPassword->CryptoSetPassword(
-          (const Byte *)(const char *)charPassword, charPassword.Len());
-        if (result != S_OK)
+        HRESULT Result = cryptoSetPassword->CryptoSetPassword(
+            (const Byte *)(const char *)charPassword,
+            charPassword.Len());
+        if (Result != S_OK)
         {
           res = NExtract::NOperationResult::kWrongPassword;
           return S_OK;
@@ -1309,28 +1314,28 @@ HRESULT CZipDecoder::Decode(
 #if 0 // ******** Annotated 7-Zip Mainline Source Code snippet Start ********
           if (!_wzAesDecoder->Init_and_CheckPassword())
 #endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
-          bool passwordIsCorrect = false;
-          if (_wzAesDecoder->CryptoSetPassword(
-              (const Byte *)(const char *)wzAesUtf8Password,
-              wzAesUtf8Password.Len()) == S_OK)
+          bool IsPasswordCorrect = false;
+          if (this->_wzAesDecoder->CryptoSetPassword(
+              (const Byte *)(const char *)WzAesUtf8Password,
+              WzAesUtf8Password.Len()) == S_OK)
           {
-            passwordIsCorrect =
-                _wzAesDecoder->Init_and_CheckPassword();
+            IsPasswordCorrect =
+                this->_wzAesDecoder->Init_and_CheckPassword();
           }
-          if (!passwordIsCorrect &&
-              wzAesCodePagePassword != wzAesUtf8Password)
+          if (!IsPasswordCorrect &&
+              WzAesCodePagePassword != WzAesUtf8Password)
           {
-            if (_wzAesDecoder->CryptoSetPassword(
-                (const Byte *)(const char *)wzAesCodePagePassword,
-                wzAesCodePagePassword.Len()) == S_OK)
+            if (this->_wzAesDecoder->CryptoSetPassword(
+                (const Byte *)(const char *)WzAesCodePagePassword,
+                WzAesCodePagePassword.Len()) == S_OK)
             {
-              passwordIsCorrect =
-                  _wzAesDecoder->Init_and_CheckPassword();
+              IsPasswordCorrect =
+                  this->_wzAesDecoder->Init_and_CheckPassword();
             }
           }
-          wzAesUtf8Password.Wipe_and_Empty();
-          wzAesCodePagePassword.Wipe_and_Empty();
-          if (!passwordIsCorrect)
+          WzAesUtf8Password.Wipe_and_Empty();
+          WzAesCodePagePassword.Wipe_and_Empty();
+          if (!IsPasswordCorrect)
           // **************** NanaZip Modification End ****************
           {
             res = NExtract::NOperationResult::kWrongPassword;

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandlerOut.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandlerOut.cpp
@@ -433,7 +433,7 @@ Z7_COM7F_IMF(CHandler::UpdateItems(ISequentialOutStream *outStream, UInt32 numIt
       }
       else
       {
-        if (!::IsSimpleAsciiString(password))
+        if (!IsSimpleAsciiString(password))
           return E_INVALIDARG;
         if (password)
           ::UnicodeStringToMultiByte2(

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandlerOut.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandlerOut.cpp
@@ -427,16 +427,19 @@ Z7_COM7F_IMF(CHandler::UpdateItems(ISequentialOutStream *outStream, UInt32 numIt
       if (options.IsAesMode)
       {
         if (password)
-          ConvertUnicodeToUTF8((LPCOLESTR)password, options.Password);
+          ::ConvertUnicodeToUTF8((LPCOLESTR)password, options.Password);
         if (options.Password.Len() > NCrypto::NWzAes::kPasswordSizeMax)
           return E_INVALIDARG;
       }
       else
       {
-        if (!IsSimpleAsciiString(password))
+        if (!::IsSimpleAsciiString(password))
           return E_INVALIDARG;
         if (password)
-          UnicodeStringToMultiByte2(options.Password, (LPCOLESTR)password, CP_OEMCP);
+          ::UnicodeStringToMultiByte2(
+              options.Password,
+              (LPCOLESTR)password,
+              CP_OEMCP);
       }
       // **************** NanaZip Modification End ****************
     }

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandlerOut.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandlerOut.cpp
@@ -427,19 +427,29 @@ Z7_COM7F_IMF(CHandler::UpdateItems(ISequentialOutStream *outStream, UInt32 numIt
       if (options.IsAesMode)
       {
         if (password)
-          ::ConvertUnicodeToUTF8((LPCOLESTR)password, options.Password);
-        if (options.Password.Len() > NCrypto::NWzAes::kPasswordSizeMax)
+        {
+          ::ConvertUnicodeToUTF8(
+              static_cast<LPCOLESTR>(password),
+              options.Password);
+        }
+        if (NCrypto::NWzAes::kPasswordSizeMax < options.Password.Len())
+        {
           return E_INVALIDARG;
+        }
       }
       else
       {
         if (!IsSimpleAsciiString(password))
+        {
           return E_INVALIDARG;
+        }
         if (password)
+        {
           ::UnicodeStringToMultiByte2(
               options.Password,
-              (LPCOLESTR)password,
+              static_cast<LPCOLESTR>(password),
               CP_OEMCP);
+        }
       }
       // **************** NanaZip Modification End ****************
     }

--- a/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandlerOut.cpp
+++ b/NanaZip.Core/SevenZip/CPP/7zip/Archive/Zip/ZipHandlerOut.cpp
@@ -412,6 +412,8 @@ Z7_COM7F_IMF(CHandler::UpdateItems(ISequentialOutStream *outStream, UInt32 numIt
       if (!m_ForceAesMode)
         options.IsAesMode = thereAreAesUpdates;
 
+      // **************** NanaZip Modification Start ****************
+#if 0 // ******** Annotated 7-Zip Mainline Source Code snippet Start ********
       if (!IsSimpleAsciiString(password))
         return E_INVALIDARG;
       if (password)
@@ -421,6 +423,22 @@ Z7_COM7F_IMF(CHandler::UpdateItems(ISequentialOutStream *outStream, UInt32 numIt
         if (options.Password.Len() > NCrypto::NWzAes::kPasswordSizeMax)
           return E_INVALIDARG;
       }
+#endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
+      if (options.IsAesMode)
+      {
+        if (password)
+          ConvertUnicodeToUTF8((LPCOLESTR)password, options.Password);
+        if (options.Password.Len() > NCrypto::NWzAes::kPasswordSizeMax)
+          return E_INVALIDARG;
+      }
+      else
+      {
+        if (!IsSimpleAsciiString(password))
+          return E_INVALIDARG;
+        if (password)
+          UnicodeStringToMultiByte2(options.Password, (LPCOLESTR)password, CP_OEMCP);
+      }
+      // **************** NanaZip Modification End ****************
     }
   }
 

--- a/NanaZip.Universal/SevenZip/CPP/7zip/UI/GUI/CompressDialog.cpp
+++ b/NanaZip.Universal/SevenZip/CPP/7zip/UI/GUI/CompressDialog.cpp
@@ -1270,18 +1270,21 @@ void CCompressDialog::OnOK()
         ::ShowErrorMessageHwndRes(*this, IDS_PASSWORD_USE_ASCII);
         return;
       }
-      if (::MessageBoxW(
-              *this,
-              ::LangString(IDS_PASSWORD_USE_ASCII),
-              L"NanaZip",
-              MB_OKCANCEL | MB_ICONWARNING) != IDOK)
+      if (IDOK != ::MessageBoxW(
+          *this,
+          ::LangString(IDS_PASSWORD_USE_ASCII),
+          L"NanaZip",
+          MB_OKCANCEL | MB_ICONWARNING))
+      {
         return;
+      }
     }
     if (IsAesMode)
     {
+      const UInt32 kWzAesPasswordSizeMax = 99;
       AString_Wipe Utf8Password;
       ::ConvertUnicodeToUTF8(this->Info.Password, Utf8Password);
-      if (Utf8Password.Len() > 99)
+      if (kWzAesPasswordSizeMax < Utf8Password.Len())
       {
         ::ShowErrorMessageHwndRes(*this, IDS_PASSWORD_TOO_LONG);
         return;

--- a/NanaZip.Universal/SevenZip/CPP/7zip/UI/GUI/CompressDialog.cpp
+++ b/NanaZip.Universal/SevenZip/CPP/7zip/UI/GUI/CompressDialog.cpp
@@ -1281,10 +1281,10 @@ void CCompressDialog::OnOK()
     }
     if (IsAesMode)
     {
-      const UInt32 kWzAesPasswordSizeMax = 99;
+      const UInt32 MaximumPasswordSize = 99;
       AString_Wipe Utf8Password;
       ::ConvertUnicodeToUTF8(this->Info.Password, Utf8Password);
-      if (kWzAesPasswordSizeMax < Utf8Password.Len())
+      if (MaximumPasswordSize < Utf8Password.Len())
       {
         ::ShowErrorMessageHwndRes(*this, IDS_PASSWORD_TOO_LONG);
         return;

--- a/NanaZip.Universal/SevenZip/CPP/7zip/UI/GUI/CompressDialog.cpp
+++ b/NanaZip.Universal/SevenZip/CPP/7zip/UI/GUI/CompressDialog.cpp
@@ -1261,26 +1261,29 @@ void CCompressDialog::OnOK()
       }
     }
 #endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
-    UString method = GetEncryptionMethodSpec();
-    const bool isAesMode = method.IsPrefixedBy_Ascii_NoCase("aes");
-    if (!IsAsciiString(Info.Password))
+    UString Method = this->GetEncryptionMethodSpec();
+    const bool IsAesMode = Method.IsPrefixedBy_Ascii_NoCase("aes");
+    if (!::IsAsciiString(this->Info.Password))
     {
-      if (!isAesMode)
+      if (!IsAesMode)
       {
-        ShowErrorMessageHwndRes(*this, IDS_PASSWORD_USE_ASCII);
+        ::ShowErrorMessageHwndRes(*this, IDS_PASSWORD_USE_ASCII);
         return;
       }
-      if (::MessageBoxW(*this, LangString(IDS_PASSWORD_USE_ASCII),
-          L"NanaZip", MB_OKCANCEL | MB_ICONWARNING) != IDOK)
+      if (::MessageBoxW(
+              *this,
+              ::LangString(IDS_PASSWORD_USE_ASCII),
+              L"NanaZip",
+              MB_OKCANCEL | MB_ICONWARNING) != IDOK)
         return;
     }
-    if (isAesMode)
+    if (IsAesMode)
     {
-      AString_Wipe utf8Password;
-      ConvertUnicodeToUTF8(Info.Password, utf8Password);
-      if (utf8Password.Len() > 99)
+      AString_Wipe Utf8Password;
+      ::ConvertUnicodeToUTF8(this->Info.Password, Utf8Password);
+      if (Utf8Password.Len() > 99)
       {
-        ShowErrorMessageHwndRes(*this, IDS_PASSWORD_TOO_LONG);
+        ::ShowErrorMessageHwndRes(*this, IDS_PASSWORD_TOO_LONG);
         return;
       }
     }

--- a/NanaZip.Universal/SevenZip/CPP/7zip/UI/GUI/CompressDialog.cpp
+++ b/NanaZip.Universal/SevenZip/CPP/7zip/UI/GUI/CompressDialog.cpp
@@ -6,6 +6,9 @@
 
 #include "../../../Common/IntToString.h"
 #include "../../../Common/StringConvert.h"
+// **************** NanaZip Modification Start ****************
+#include "../../../Common/UTFConvert.h"
+// **************** NanaZip Modification End ****************
 
 #include "../../../Windows/FileDir.h"
 #include "../../../Windows/FileName.h"

--- a/NanaZip.Universal/SevenZip/CPP/7zip/UI/GUI/CompressDialog.cpp
+++ b/NanaZip.Universal/SevenZip/CPP/7zip/UI/GUI/CompressDialog.cpp
@@ -1241,6 +1241,8 @@ void CCompressDialog::OnOK()
   _password1Control.GetText(Info.Password);
   if (IsZipFormat())
   {
+    // **************** NanaZip Modification Start ****************
+#if 0 // ******** Annotated 7-Zip Mainline Source Code snippet Start ********
     if (!IsAsciiString(Info.Password))
     {
       ShowErrorMessageHwndRes(*this, IDS_PASSWORD_USE_ASCII);
@@ -1255,6 +1257,31 @@ void CCompressDialog::OnOK()
         return;
       }
     }
+#endif // ******** Annotated 7-Zip Mainline Source Code snippet End ********
+    UString method = GetEncryptionMethodSpec();
+    const bool isAesMode = method.IsPrefixedBy_Ascii_NoCase("aes");
+    if (!IsAsciiString(Info.Password))
+    {
+      if (!isAesMode)
+      {
+        ShowErrorMessageHwndRes(*this, IDS_PASSWORD_USE_ASCII);
+        return;
+      }
+      if (::MessageBoxW(*this, LangString(IDS_PASSWORD_USE_ASCII),
+          L"NanaZip", MB_OKCANCEL | MB_ICONWARNING) != IDOK)
+        return;
+    }
+    if (isAesMode)
+    {
+      AString_Wipe utf8Password;
+      ConvertUnicodeToUTF8(Info.Password, utf8Password);
+      if (utf8Password.Len() > 99)
+      {
+        ShowErrorMessageHwndRes(*this, IDS_PASSWORD_TOO_LONG);
+        return;
+      }
+    }
+    // **************** NanaZip Modification End ****************
   }
   if (!IsShowPasswordChecked())
   {


### PR DESCRIPTION
## Summary

- keep the existing ANSI code-page password path as the first choice for
  backward compatibility;
- retry WinZip AES password verification with UTF-8 bytes when the ANSI bytes
  are different and fail verification;
- leave traditional ZipCrypto and PKZIP strong encryption behavior unchanged.

## Root cause

The ZIP handler converted every password from UTF-16 to `CP_ACP` before passing
it to the crypto filter. WinZip AES archives created with UTF-8 password bytes
therefore failed on Windows whenever the non-ASCII password produced different
bytes in the active ANSI code page.

WinZip AES provides a password verification value, so the handler can safely
retain the existing ANSI behavior and retry the same password as UTF-8 only
after the original candidate is rejected.

## Validation

- reproduced the failure with NanaZip 7.0 Preview 7.0.1800.0 and the 218-byte
  sample from #972;
- confirmed that the same archive and password pass with 7-Zip 23.01;
- verified that the source diff passes `git diff --check`;
- completed an x64 Release console build in the
  [fork validation workflow](https://github.com/wyjh233/NanaZip/actions/runs/32377552466);
- tested the built console binary against four WinZip AES-256 archives: the
  UTF-8 issue sample, a UTF-8 password that is also representable in CP936, a
  legacy CP936-encoded password, and an ASCII password; all four passed with
  exit code 0.

Fixes #972
